### PR TITLE
[codex] add devpod-linux cask and updater workflow

### DIFF
--- a/.github/workflows/update-devpod-linux.yml
+++ b/.github/workflows/update-devpod-linux.yml
@@ -1,0 +1,139 @@
+name: Update DevPod Linux Cask
+
+on:
+  schedule:
+    # Run daily at 8 AM UTC (after other cask updates)
+    - cron: '0 8 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  update-cask:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get latest DevPod release
+        id: get_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Get latest stable (non-prerelease) release from skevetter/devpod.
+          RELEASE_JSON=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/skevetter/devpod/releases/latest")
+
+          TAG_NAME=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
+          VERSION="${TAG_NAME#v}"
+          ASSET_URL=$(echo "$RELEASE_JSON" | jq -r \
+            '.assets[] | select(.name == "DevPod_linux_amd64.deb") | .browser_download_url')
+
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "ERROR: Failed to read release version"
+            echo "$RELEASE_JSON"
+            exit 1
+          fi
+
+          if [ -z "$ASSET_URL" ] || [ "$ASSET_URL" = "null" ]; then
+            echo "ERROR: DevPod_linux_amd64.deb asset not found in latest release"
+            echo "$RELEASE_JSON"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "asset_url=$ASSET_URL" >> "$GITHUB_OUTPUT"
+          echo "Latest version: $VERSION"
+          echo "Asset URL: $ASSET_URL"
+
+      - name: Get current cask values
+        id: current_values
+        run: |
+          set -euo pipefail
+          CURRENT_VERSION=$(sed -nE 's/^[[:space:]]*version "([^"]+)"/\1/p' Casks/devpod-linux.rb | head -n1)
+          CURRENT_SHA=$(sed -nE 's/^[[:space:]]*sha256 x86_64_linux: "([a-f0-9]{64})"/\1/p' Casks/devpod-linux.rb | head -n1)
+
+          if [ -z "$CURRENT_VERSION" ] || [ -z "$CURRENT_SHA" ]; then
+            echo "ERROR: Failed to read current version/sha from Casks/devpod-linux.rb"
+            exit 1
+          fi
+
+          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "linux_sha=$CURRENT_SHA" >> "$GITHUB_OUTPUT"
+          echo "Current version: $CURRENT_VERSION"
+          echo "Current Linux SHA256: $CURRENT_SHA"
+
+      - name: Download and calculate SHA256
+        id: get_sha
+        run: |
+          set -euo pipefail
+          ASSET_URL="${{ steps.get_release.outputs.asset_url }}"
+
+          curl -fSL "$ASSET_URL" -o /tmp/DevPod_linux_amd64.deb
+          LINUX_SHA=$(sha256sum /tmp/DevPod_linux_amd64.deb | awk '{print $1}')
+          rm -f /tmp/DevPod_linux_amd64.deb
+
+          echo "linux_sha=$LINUX_SHA" >> "$GITHUB_OUTPUT"
+          echo "New Linux SHA256: $LINUX_SHA"
+
+      - name: Check if update needed
+        id: check_update
+        run: |
+          set -euo pipefail
+          NEEDS_UPDATE=false
+
+          if [ "${{ steps.get_release.outputs.version }}" != "${{ steps.current_values.outputs.version }}" ]; then
+            echo "Version changed: ${{ steps.current_values.outputs.version }} -> ${{ steps.get_release.outputs.version }}"
+            NEEDS_UPDATE=true
+          fi
+
+          if [ "${{ steps.get_sha.outputs.linux_sha }}" != "${{ steps.current_values.outputs.linux_sha }}" ]; then
+            echo "Linux SHA256 changed"
+            NEEDS_UPDATE=true
+          fi
+
+          echo "needs_update=$NEEDS_UPDATE" >> "$GITHUB_OUTPUT"
+          if [ "$NEEDS_UPDATE" = "false" ]; then
+            echo "Already up to date"
+          fi
+
+      - name: Update cask
+        if: steps.check_update.outputs.needs_update == 'true'
+        env:
+          VERSION: ${{ steps.get_release.outputs.version }}
+          LINUX_SHA: ${{ steps.get_sha.outputs.linux_sha }}
+        run: |
+          set -euo pipefail
+
+          # Update only the dynamic fields to keep the rest of the cask intact.
+          perl -0pi -e 's/^(\s*version\s+)"[^"]+"/${1}"$ENV{VERSION}"/m' Casks/devpod-linux.rb
+          perl -0pi -e 's/^(\s*sha256\s+x86_64_linux:\s+)"[a-f0-9]{64}"/${1}"$ENV{LINUX_SHA}"/m' Casks/devpod-linux.rb
+
+          UPDATED_VERSION=$(sed -nE 's/^[[:space:]]*version "([^"]+)"/\1/p' Casks/devpod-linux.rb | head -n1)
+          UPDATED_SHA=$(sed -nE 's/^[[:space:]]*sha256 x86_64_linux: "([a-f0-9]{64})"/\1/p' Casks/devpod-linux.rb | head -n1)
+
+          if [ "$UPDATED_VERSION" != "$VERSION" ]; then
+            echo "ERROR: version update failed (expected $VERSION, got $UPDATED_VERSION)"
+            exit 1
+          fi
+          if [ "$UPDATED_SHA" != "$LINUX_SHA" ]; then
+            echo "ERROR: sha update failed (expected $LINUX_SHA, got $UPDATED_SHA)"
+            exit 1
+          fi
+
+          echo "Updated cask:"
+          sed -n '1,120p' Casks/devpod-linux.rb
+
+      - name: Commit and push changes
+        if: steps.check_update.outputs.needs_update == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/devpod-linux.rb
+          git commit -m "Update devpod-linux cask to v${{ steps.get_release.outputs.version }}"
+          git push

--- a/Casks/devpod-linux.rb
+++ b/Casks/devpod-linux.rb
@@ -1,0 +1,89 @@
+cask "devpod-linux" do
+  arch intel: "amd64"
+  os linux: "linux"
+
+  version "0.12.15"
+  sha256 x86_64_linux: "39e12877a972d958dfa324adb0920091e3fd4075a1aea3146141b12e48a54a5e"
+
+  url "https://github.com/skevetter/devpod/releases/download/v#{version}/DevPod_#{os}_#{arch}.deb",
+      verified: "github.com/skevetter/devpod/"
+  name "DevPod"
+  desc "Open-source dev environments based on devcontainer.json"
+  homepage "https://github.com/skevetter/devpod"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  binary "usr/bin/devpod"
+  binary "usr/bin/DevPod Desktop", target: "devpod-desktop"
+  artifact "usr/share/applications/DevPod.desktop",
+           target: "#{Dir.home}/.local/share/applications/devpod.desktop"
+  artifact "usr/share/icons/hicolor/32x32/apps/DevPod Desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/32x32/apps/devpod-desktop.png"
+  artifact "usr/share/icons/hicolor/128x128/apps/DevPod Desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/128x128/apps/devpod-desktop.png"
+  artifact "usr/share/icons/hicolor/256x256@2/apps/DevPod Desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/256x256@2/apps/devpod-desktop.png"
+
+  preflight do
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/32x32/apps"
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/128x128/apps"
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/256x256@2/apps"
+
+    deb = "#{staged_path}/DevPod_#{os}_#{arch}.deb"
+    system "ar", "x", deb, chdir: staged_path
+
+    data_archive = Dir["#{staged_path}/data.tar.*"].first
+    raise "unable to find data archive in #{deb}" if data_archive.blank?
+
+    case data_archive
+    when /\.tar\.gz$/
+      system "tar", "-xzf", data_archive, "-C", staged_path
+    when /\.tar\.xz$/
+      system "tar", "-xJf", data_archive, "-C", staged_path
+    when /\.tar\.zst$/
+      system "sh", "-c", "unzstd -c '#{data_archive}' | tar -xf - -C '#{staged_path}'"
+    else
+      system "tar", "-xf", data_archive, "-C", staged_path
+    end
+
+    desktop_file = "#{staged_path}/usr/share/applications/DevPod.desktop"
+    desktop_contents = File.read(desktop_file)
+    desktop_contents.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/devpod-desktop")
+    icon_path = "#{Dir.home}/.local/share/icons/hicolor/256x256@2/apps/devpod-desktop.png"
+    desktop_contents.gsub!(/^Icon=.*/, "Icon=#{icon_path}")
+    File.write(desktop_file, desktop_contents)
+  end
+
+  zap trash: [
+    "~/.cache/sh.loft.devpod",
+    "~/.config/sh.loft.devpod",
+    "~/.devpod",
+    "~/.local/share/sh.loft.devpod",
+  ]
+
+  caveats <<~EOS
+    Provider setup (validated against DevPod v0.12.15):
+
+    Works by short name:
+      devpod provider add docker
+      devpod provider add kubernetes
+      devpod provider add aws -o AWS_REGION=us-east-1
+      devpod provider add gcloud -o PROJECT=<gcp-project-id>
+      devpod provider add ssh -o HOST=<host-or-ip>
+
+    Some list-available entries currently 404 by short name. Use explicit source:
+      devpod provider add loft-sh/devpod-provider-azure
+      devpod provider add loft-sh/devpod-provider-digitalocean
+      devpod provider add loft-sh/devpod-provider-terraform
+      devpod provider add loft-sh/devpod-provider-civo
+      devpod provider add loft-sh/devpod-provider-ecs
+      devpod provider add loft-sh/devpod-provider-dockerless
+
+    Discover provider names:
+      devpod provider list-available
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -54,10 +54,34 @@ The upstream RCC Homebrew package is macOS-only. This cask provides cross-platfo
 ### DevPod (Linux Cask)
 
 DevPod - Open Source Dev-Environments-As-Code. Contains both the Desktop UI and CLI.
-See [loft-sh/devpod](https://github.com/loft-sh/devpod) for more details.
+This cask follows the Bluefin/uBlue Linux tap convention of using a Linux-specific token (`devpod-linux`).
+See [skevetter/devpod](https://github.com/skevetter/devpod) for release details.
 
 > [!NOTE]
-> This Cask uses the `tar.gz` distribution to support immutable distros (like Bluefin/uBlue) better than AppImages.
+> This cask uses the upstream `.deb` asset so both the desktop app and `devpod` CLI are installed together.
+
+```bash
+brew install --cask joshyorko/tools/devpod-linux
+devpod version
+devpod-desktop
+
+# Provider setup
+devpod provider add docker
+devpod provider add kubernetes
+devpod provider add gcloud -o PROJECT=<gcp-project-id>   # Google Cloud
+devpod provider add aws -o AWS_REGION=us-east-1
+devpod provider add ssh -o HOST=<host-or-ip>
+
+# Some providers currently require explicit source
+devpod provider add loft-sh/devpod-provider-azure
+devpod provider add loft-sh/devpod-provider-digitalocean
+devpod provider add loft-sh/devpod-provider-terraform
+devpod provider add loft-sh/devpod-provider-civo
+devpod provider add loft-sh/devpod-provider-ecs
+devpod provider add loft-sh/devpod-provider-dockerless
+
+devpod provider list-available
+```
 
 ## For Brewfile Users
 


### PR DESCRIPTION
## Summary
This PR adds a Linux-focused `devpod-linux` cask and an automated updater workflow so the tap can install and keep DevPod current on Bluefin/uBlue-style immutable systems.

The cask installs both:
- the CLI (`devpod`)
- the desktop UI launcher (`devpod-desktop`)

## User Impact
Before this change, the tap had no DevPod package, so users had to install manually and track updates themselves.
After this change, users can run:

```bash
brew install --cask joshyorko/tools/devpod-linux
```

and get both CLI + UI from one install path.

## Root Cause
There was no maintained Linux cask in this tap for the actively maintained DevPod fork (`skevetter/devpod`), and no release-tracking automation to keep checksums/versions updated.

## Implementation Details
- Added `Casks/devpod-linux.rb`:
  - Downloads upstream Linux `.deb` release asset from `skevetter/devpod`.
  - Extracts the `.deb` in cask staging via `ar` + `tar`.
  - Links binaries through Homebrew (`devpod`, `devpod-desktop`).
  - Publishes desktop entry + icons into user-writable paths under `~/.local/share/...`.
  - Rewrites desktop `Exec`/`Icon` to Homebrew/user-space locations.
  - Includes provider caveats for common providers and known explicit-source cases.
- Added `.github/workflows/update-devpod-linux.yml`:
  - Runs on schedule and manual dispatch.
  - Fetches latest stable GitHub release metadata.
  - Resolves `DevPod_linux_amd64.deb`, computes SHA256, and updates the cask.
  - Commits/pushes only when version or SHA changes.
- Updated `README.md` with install + provider usage docs for `devpod-linux`.

## Immutable OS / /usr Clarification
This cask does **not** write into host `/usr`.
Paths like `usr/bin/...` and `usr/share/...` are source paths inside the extracted package payload in the staging directory. Installed artifacts are linked/copied to Homebrew prefix and user-writable directories.

## Validation
- `brew style Casks/devpod-linux.rb` (passes)
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/update-devpod-linux.yml")'` (passes)

## Notes
I did not run a full `brew install --cask ...` integration install in this environment; runtime verification should be done on a Bluefin host with the tap branch.
