### PR TITLE
[codex] Add auto-update planning and release pruning

### DIFF
--- a/.github/workflows/tap-auto-update.yml
+++ b/.github/workflows/tap-auto-update.yml
@@ -30,6 +30,7 @@ env:
   DAGGER_VERSION: "0.20.3"
   GH_TOKEN: ${{ github.token }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  RELEASE_RETENTION_PER_PACKAGE: "3"
 
 jobs:
   resolve:
@@ -38,7 +39,8 @@ jobs:
     outputs:
       slot_id: ${{ steps.slot.outputs.slot_id }}
       trigger_source: ${{ steps.slot.outputs.trigger_source }}
-      package_ids_json: ${{ steps.slot.outputs.package_ids_json }}
+      package_ids_json: ${{ steps.packages.outputs.package_ids_json }}
+      has_packages: ${{ steps.packages.outputs.has_packages }}
       matrix: ${{ steps.packages.outputs.matrix }}
     steps:
     - name: Checkout repository
@@ -71,33 +73,33 @@ jobs:
           trigger_source="schedule:$EVENT_SCHEDULE"
         fi
 
-        package_ids_json="$(
-          jq -cer --arg slot_id "$slot_id" '
-            map(select(.id == $slot_id) | .packageIds)
-            | if length == 1 then .[0] else error("Unknown slot id for Tap Auto Update: \($slot_id)") end
-          ' dagger/tap-pipeline/auto-update-slots.json
-        )"
-
         echo "slot_id=$slot_id" >> "$GITHUB_OUTPUT"
         echo "trigger_source=$trigger_source" >> "$GITHUB_OUTPUT"
-        echo "package_ids_json=$package_ids_json" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve packages needing update
+      id: dagger_plan
+      uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77  # v8.4.1
+      with:
+        version: ${{ env.DAGGER_VERSION }}
+        module: ./dagger/tap-pipeline
+        cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        enable-github-summary: "true"
+        call: >-
+          auto-update-status
+          --slot-id="${{ steps.slot.outputs.slot_id }}"
 
     - name: Build matrix from slot output
       id: packages
       env:
         SLOT_ID: ${{ steps.slot.outputs.slot_id }}
         TRIGGER_SOURCE: ${{ steps.slot.outputs.trigger_source }}
-        PACKAGE_IDS_JSON: ${{ steps.slot.outputs.package_ids_json }}
+        STATUS_JSON: ${{ steps.dagger_plan.outputs.output }}
       run: |
         set -euo pipefail
+        PACKAGE_IDS_JSON="$(jq -cer '[.[] | select(.needs_update) | .id]' <<<"$STATUS_JSON")"
         matrix="$(jq -cn --argjson package_ids "$PACKAGE_IDS_JSON" '{include: ($package_ids | map({package_id: .}))}')"
         count="$(jq '.include | length' <<<"$matrix")"
-        package_ids="$(jq -r 'join(", ")' <<<"$PACKAGE_IDS_JSON")"
-
-        if [ "$count" -eq 0 ]; then
-          echo "Auto-update slot $SLOT_ID resolved zero packages, which is not allowed." >&2
-          exit 1
-        fi
+        package_ids="$(jq -r 'if length == 0 then "none" else join(", ") end' <<<"$PACKAGE_IDS_JSON")"
 
         echo "Resolved slot $SLOT_ID -> $package_ids"
         {
@@ -105,13 +107,20 @@ jobs:
           echo
           echo "Slot id: \`$SLOT_ID\`"
           echo "Trigger: \`$TRIGGER_SOURCE\`"
-          echo "Package ids: $package_ids"
+          echo "Packages needing build: $package_ids"
+          echo
+          echo "### Package Status"
+          echo
+          jq -r '.[] | "- \(.id): current=\(.current_version) upstream=\(.upstream_version) needs_update=\(.needs_update)"' <<<"$STATUS_JSON"
         } >> "$GITHUB_STEP_SUMMARY"
 
+        echo "package_ids_json=$PACKAGE_IDS_JSON" >> "$GITHUB_OUTPUT"
         echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+        echo "has_packages=$([ "$count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve
+    if: needs.resolve.outputs.has_packages == 'true'
     name: Build ${{ matrix.package_id }} Bundle
     runs-on: ubuntu-latest
     strategy:
@@ -142,6 +151,7 @@ jobs:
     needs:
     - resolve
     - build
+    if: needs.resolve.outputs.has_packages == 'true'
     name: Publish Auto Update Slot
     runs-on: ubuntu-latest
     steps:
@@ -199,6 +209,11 @@ jobs:
 
           gh release upload "$release_tag" "${artifacts[@]}" --clobber
           node scripts/apply-release-bundle.mjs --bundle "$bundle_dir" --repo "$GITHUB_WORKSPACE" >/dev/null
+          node scripts/prune-package-releases.mjs \
+            --repo "$GITHUB_REPOSITORY" \
+            --package-id "$package_id" \
+            --current-tag "$release_tag" \
+            --keep "$RELEASE_RETENTION_PER_PACKAGE"
 
           if git diff --quiet -- "$homebrew_path"; then
             result="unchanged"
@@ -251,3 +266,11 @@ jobs:
           echo "Updated packages: $(printf '%s, ' "${updated_ids[@]}" | sed 's/, $//')"
           echo "Commit: \`$commit_message\`"
         } >> "$GITHUB_STEP_SUMMARY"
+
+  no_updates_required:
+    needs: resolve
+    if: needs.resolve.outputs.has_packages != 'true'
+    name: No Auto Updates Required
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "No upstream package updates detected for this slot."

--- a/.github/workflows/tap-manual.yml
+++ b/.github/workflows/tap-manual.yml
@@ -23,6 +23,7 @@ env:
   DAGGER_VERSION: "0.20.3"
   GH_TOKEN: ${{ github.token }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  RELEASE_RETENTION_PER_PACKAGE: "3"
 
 jobs:
   run:
@@ -93,6 +94,11 @@ jobs:
 
         gh release upload "$release_tag" "${artifacts[@]}" --clobber
         node scripts/apply-release-bundle.mjs --bundle "$bundle_dir" --repo "$GITHUB_WORKSPACE"
+        node scripts/prune-package-releases.mjs \
+          --repo "$GITHUB_REPOSITORY" \
+          --package-id "$PACKAGE_ID" \
+          --current-tag "$release_tag" \
+          --keep "$RELEASE_RETENTION_PER_PACKAGE"
 
         if git diff --quiet; then
           exit 0

--- a/Casks/t3-code-linux.rb
+++ b/Casks/t3-code-linux.rb
@@ -31,7 +31,10 @@ cask "t3-code-linux" do
     system appimage, "--appimage-extract", chdir: staged_path, out: File::NULL
 
     desktop_file = "#{staged_path}/t3-code-linux.desktop"
-    desktop_contents = File.read("#{staged_path}/squashfs-root/t3-code-desktop.desktop")
+    desktop_source = Dir["#{staged_path}/squashfs-root/*.desktop"].find { |path| File.file?(path) }
+    raise "No desktop entry found in extracted T3 Code AppImage" unless desktop_source
+
+    desktop_contents = File.read(desktop_source)
     desktop_contents.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/t3-code-linux %U")
     desktop_contents.gsub!(
       /^Icon=.*/,
@@ -39,10 +42,11 @@ cask "t3-code-linux" do
     )
     File.write(desktop_file, desktop_contents)
 
-    FileUtils.cp(
-      "#{staged_path}/squashfs-root/usr/share/icons/hicolor/1024x1024/apps/t3-code-desktop.png",
-      "#{staged_path}/t3-code-linux.png"
-    )
+    icon_source = Dir["#{staged_path}/squashfs-root/usr/share/icons/hicolor/1024x1024/apps/*.png"]
+      .find { |path| File.file?(path) }
+    raise "No 1024x1024 icon found in extracted T3 Code AppImage" unless icon_source
+
+    FileUtils.cp(icon_source, "#{staged_path}/t3-code-linux.png")
 
     wrapper = "#{staged_path}/t3-code-linux-wrapper"
     File.write(wrapper, <<~SH)

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -27,6 +27,22 @@ function parseTextLines(output: string): string[] {
     .filter((line) => line.length > 0)
 }
 
+function stripRequiredPrefix(value: string, prefix?: string): string {
+  if (!prefix) {
+    return value
+  }
+
+  if (!value.startsWith(prefix)) {
+    throw new Error(`Expected ${value} to start with ${prefix}`)
+  }
+
+  return value.slice(prefix.length)
+}
+
+function githubApiRepoUrl(repoUrl: string): string {
+  return repoUrl.replace("https://github.com/", "https://api.github.com/repos/")
+}
+
 function tapStagingCommands(packageId: string): string[] {
   switch (packageId) {
     case "rcc":
@@ -123,6 +139,7 @@ type VoxtypeBuild = {
   assetName: string
   commit: string
   container: Container
+  upstreamTag: string
   version: string
 }
 
@@ -162,6 +179,15 @@ type T3CodeBuild = {
   upstreamTag: string
   container: Container
   asset: DownloadedAsset
+}
+
+type AutoUpdatePackageStatus = {
+  id: string
+  kind: string
+  homebrew_path: string
+  current_version: string
+  upstream_version: string
+  needs_update: boolean
 }
 
 @object()
@@ -208,6 +234,54 @@ export class TapPipeline {
         homebrew_path: entry.homebrewPath,
       })),
     )
+  }
+
+  @func()
+  async autoUpdateStatus(slotId: string): Promise<string> {
+    const entries = slotPackages(parseAutoUpdateSlotId(slotId))
+    const statuses = await Promise.all(entries.map(async (entry): Promise<AutoUpdatePackageStatus> => {
+      const currentVersion = await this.currentPackagedVersion(entry.id)
+      const upstreamVersion = await this.resolveUpstreamVersion(entry.id)
+
+      return {
+        id: entry.id,
+        kind: entry.kind,
+        homebrew_path: entry.homebrewPath,
+        current_version: currentVersion,
+        upstream_version: upstreamVersion,
+        needs_update: currentVersion !== upstreamVersion,
+      }
+    }))
+
+    return json(statuses)
+  }
+
+  @func()
+  async packagesNeedingAutoUpdate(slotId: string): Promise<string> {
+    const entries = JSON.parse(await this.autoUpdateStatus(slotId)) as AutoUpdatePackageStatus[]
+    return json(entries.filter((entry) => entry.needs_update).map((entry) => entry.id))
+  }
+
+  private packageEntry(packageId: string) {
+    const entry = packageSummaries().find((candidate) => candidate.id === packageId)
+
+    if (!entry) {
+      throw new Error(`Unknown package: ${packageId}`)
+    }
+
+    return entry
+  }
+
+  private async currentPackagedVersion(packageId: string): Promise<string> {
+    const entry = this.packageEntry(packageId)
+    const contents = await this.source.file(entry.homebrewPath).contents()
+    const match = contents.match(/^\s*version "([^"]+)"/m)
+
+    if (!match) {
+      throw new Error(`Failed to resolve packaged version from ${entry.homebrewPath}`)
+    }
+
+    return match[1]
   }
 
   private t3BaseContainer(): Container {
@@ -383,12 +457,12 @@ export class TapPipeline {
       artifactSha256: sha256,
       downloadUrl: `https://github.com/${TAP_REPOSITORY}/releases/download/voxtype-${build.version}/${build.assetName}`,
       releaseTitle: `Voxtype ${build.version} Homebrew artifact`,
-      releaseNotes: `Homebrew artifact built from peteonrails/voxtype@${build.version}`,
+      releaseNotes: `Homebrew artifact built from peteonrails/voxtype ${build.upstreamTag}`,
       commitMessage: `Update voxtype formula to ${build.version}`,
       upstream: {
         kind: "git",
         repo: "https://github.com/peteonrails/voxtype",
-        ref: "refs/tags/v0.6.4",
+        ref: `refs/tags/${build.upstreamTag}`,
         version: build.version,
         commit: build.commit,
       },
@@ -441,43 +515,12 @@ export class TapPipeline {
   }
 
   private async buildVscodeArtifact(tap: Directory, sourceUrl?: string, version?: string): Promise<VscodeBuild> {
-    const resolvedSourceUrl = sourceUrl ?? "https://update.code.visualstudio.com/latest/linux-rpm-x64/insider"
-    const metadataContainer = dag
-      .container()
-      .from(NODE_IMAGE)
-      .withExec([
-        "bash",
-        "-lc",
-        "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates cpio curl jq rpm tar && rm -rf /var/lib/apt/lists/*",
-      ])
-      .withEnvVariable("SOURCE_URL", resolvedSourceUrl)
-      .withExec([
-        "bash",
-        "-lc",
-        [
-          "set -euo pipefail",
-          "resolved_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \"$SOURCE_URL\")",
-          "curl -fsSL \"$resolved_url\" -o /tmp/vscode-insiders-source.rpm",
-          "package_version=$(rpm -qp --queryformat '%{VERSION}' /tmp/vscode-insiders-source.rpm)",
-          "release_build=$(rpm -qp --queryformat '%{RELEASE}' /tmp/vscode-insiders-source.rpm)",
-          "commit_sha=$(printf '%s' \"$resolved_url\" | sed -nE 's#^.*/download/insider/([0-9a-f]+)/.*#\\1#p')",
-          "commit_short=${commit_sha:0:12}",
-          "printf 'resolved_url=%s\\npackage_version=%s\\nrelease_build=%s\\ncask_version=%s,%s,%s\\ncommit_sha=%s\\n' \"$resolved_url\" \"$package_version\" \"$release_build\" \"$package_version\" \"$release_build\" \"$commit_short\" \"$commit_sha\"",
-        ].join("\n"),
-      ])
-
-    const metadata = Object.fromEntries(
-      parseTextLines(await metadataContainer.stdout()).map((line) => {
-        const [key, ...rest] = line.split("=")
-        return [key, rest.join("=")]
-      }),
-    )
-
-    const resolvedUrl = String(metadata.resolved_url)
-    const packageVersion = String(metadata.package_version)
-    const releaseBuild = String(metadata.release_build)
-    const commitSha = String(metadata.commit_sha)
-    const caskVersion = version && version.length > 0 ? version : String(metadata.cask_version)
+    const metadata = await this.resolveVscodeMetadata(sourceUrl)
+    const resolvedUrl = metadata.resolvedUrl
+    const packageVersion = metadata.packageVersion
+    const releaseBuild = metadata.releaseBuild
+    const commitSha = metadata.commitSha
+    const caskVersion = version && version.length > 0 ? version : metadata.caskVersion
     const assetName = `vscode-insiders-linux-${caskVersion.replace(/,/g, "-")}.tar.gz`
     const artifactPath = `/tmp/${assetName}`
 
@@ -512,8 +555,11 @@ export class TapPipeline {
     }
   }
 
-  private async buildVoxtypeArtifact(tap: Directory, ref = "refs/tags/v0.6.4", version?: string): Promise<VoxtypeBuild> {
-    const upstreamRef = dag.git("https://github.com/peteonrails/voxtype").ref(ref)
+  private async buildVoxtypeArtifact(tap: Directory, ref?: string, version?: string): Promise<VoxtypeBuild> {
+    const upstreamTag = ref && ref.length > 0
+      ? ref.replace(/^refs\/tags\//, "")
+      : (await this.fetchJson("https://api.github.com/repos/peteonrails/voxtype/releases/latest") as { tag_name: string }).tag_name
+    const upstreamRef = dag.git("https://github.com/peteonrails/voxtype").ref(`refs/tags/${upstreamTag}`)
     const upstreamTree = upstreamRef.tree({ discardGitDir: true })
     const commit = await upstreamRef.commit()
     const cargoToml = await upstreamTree.file("Cargo.toml").contents()
@@ -580,6 +626,7 @@ export class TapPipeline {
       assetName,
       commit,
       container,
+      upstreamTag,
       version: resolvedVersion,
     }
   }
@@ -607,6 +654,94 @@ export class TapPipeline {
       .stdout()
 
     return JSON.parse(output)
+  }
+
+  private async resolveVscodeMetadata(sourceUrl?: string): Promise<{
+    resolvedUrl: string
+    packageVersion: string
+    releaseBuild: string
+    commitSha: string
+    caskVersion: string
+  }> {
+    const resolvedSourceUrl = sourceUrl ?? "https://update.code.visualstudio.com/latest/linux-rpm-x64/insider"
+    const resolvedUrl = (await dag
+      .container()
+      .from(NODE_IMAGE)
+      .withExec([
+        "node",
+        "--input-type=module",
+        "-e",
+        [
+          "const url = process.argv[1]",
+          "const response = await fetch(url, { method: 'HEAD', redirect: 'follow' })",
+          "if (!response.ok) {",
+          "  throw new Error(`Failed to resolve ${url}: ${response.status}`)",
+          "}",
+          "process.stdout.write(response.url)",
+        ].join("\n"),
+        resolvedSourceUrl,
+      ])
+      .stdout()).trim()
+
+    const match = resolvedUrl.match(/\/download\/insider\/([0-9a-f]+)\/code-insiders-([0-9.]+)-(.+)\.x86_64\.rpm$/)
+
+    if (!match) {
+      throw new Error(`Failed to parse VS Code Insiders metadata from ${resolvedUrl}`)
+    }
+
+    const [, commitSha, packageVersion, releaseBuild] = match
+    const commitShort = commitSha.slice(0, 12)
+
+    return {
+      resolvedUrl,
+      packageVersion,
+      releaseBuild,
+      commitSha,
+      caskVersion: `${packageVersion},${releaseBuild},${commitShort}`,
+    }
+  }
+
+  private async resolveUpstreamVersion(packageId: string): Promise<string> {
+    const entry = this.packageEntry(packageId)
+
+    switch (entry.autoUpdate.kind) {
+      case "github_release_latest_tag": {
+        const repo = entry.upstream.kind === "github_release" || entry.upstream.kind === "git"
+          ? entry.upstream.repo
+          : undefined
+
+        if (!repo) {
+          throw new Error(`Expected GitHub-backed upstream for ${packageId}`)
+        }
+
+        const release = await this.fetchJson(`${githubApiRepoUrl(repo)}/releases/latest`) as {
+          tag_name: string
+        }
+        return stripRequiredPrefix(release.tag_name, entry.autoUpdate.stripPrefix)
+      }
+      case "git_head_sha": {
+        if (entry.upstream.kind !== "git") {
+          throw new Error(`Expected git upstream for ${packageId}`)
+        }
+
+        const ref = entry.autoUpdate.ref
+        const commit = await this.fetchJson(`${githubApiRepoUrl(entry.upstream.repo)}/commits/${ref}`) as {
+          sha: string
+        }
+        const shaLength = entry.autoUpdate.shaLength ?? 12
+        return `${entry.autoUpdate.prefix ?? ""}${commit.sha.slice(0, shaLength)}`
+      }
+      case "rpm_redirect": {
+        const sourceUrl = entry.autoUpdate.sourceUrl
+          ?? (entry.upstream.kind === "rpm" ? entry.upstream.sourceUrl : undefined)
+
+        if (!sourceUrl) {
+          throw new Error(`Expected rpm source URL for ${packageId}`)
+        }
+
+        return (await this.resolveVscodeMetadata(sourceUrl)).caskVersion
+      }
+    }
   }
 
   private downloadAsset(container: Container, url: string, path: string): Container {

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -8,6 +8,12 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     kind: "source_build_node_formula",
     homebrewPath: "Formula/t3code-cli-main.rb",
     supportsPrCi: true,
+    autoUpdate: {
+      kind: "git_head_sha",
+      ref: "main",
+      prefix: "smoke.",
+      shaLength: 12,
+    },
     upstream: {
       kind: "git",
       repo: "https://github.com/pingdotgg/t3code",
@@ -19,6 +25,9 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     kind: "rpm_repack_cask",
     homebrewPath: "Casks/vscode-insiders-linux.rb",
     supportsPrCi: true,
+    autoUpdate: {
+      kind: "rpm_redirect",
+    },
     upstream: {
       kind: "rpm",
       sourceUrl: "https://update.code.visualstudio.com/latest/linux-rpm-x64/insider",
@@ -29,10 +38,14 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     kind: "source_build_rust_formula",
     homebrewPath: "Formula/voxtype.rb",
     supportsPrCi: true,
+    autoUpdate: {
+      kind: "github_release_latest_tag",
+      stripPrefix: "v",
+    },
     upstream: {
       kind: "git",
       repo: "https://github.com/peteonrails/voxtype",
-      ref: "refs/tags/v0.6.4",
+      ref: "refs/tags/v0.6.5",
     },
   },
   {
@@ -40,6 +53,10 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     kind: "github_release_binary_cask",
     homebrewPath: "Casks/rcc.rb",
     supportsPrCi: true,
+    autoUpdate: {
+      kind: "github_release_latest_tag",
+      stripPrefix: "v",
+    },
     upstream: {
       kind: "github_release",
       repo: "https://github.com/joshyorko/rcc",
@@ -51,6 +68,10 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     kind: "github_release_binary_cask",
     homebrewPath: "Casks/action-server.rb",
     supportsPrCi: true,
+    autoUpdate: {
+      kind: "github_release_latest_tag",
+      stripPrefix: "action-server-v",
+    },
     upstream: {
       kind: "github_release",
       repo: "https://github.com/joshyorko/actions",
@@ -63,6 +84,10 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     kind: "github_release_deb_cask",
     homebrewPath: "Casks/devpod-linux.rb",
     supportsPrCi: true,
+    autoUpdate: {
+      kind: "github_release_latest_tag",
+      stripPrefix: "v",
+    },
     upstream: {
       kind: "github_release",
       repo: "https://github.com/skevetter/devpod",
@@ -74,6 +99,10 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     kind: "github_release_appimage_cask",
     homebrewPath: "Casks/t3-code-linux.rb",
     supportsPrCi: true,
+    autoUpdate: {
+      kind: "github_release_latest_tag",
+      stripPrefix: "v",
+    },
     upstream: {
       kind: "github_release",
       repo: "https://github.com/pingdotgg/t3code",

--- a/dagger/tap-pipeline/src/types.ts
+++ b/dagger/tap-pipeline/src/types.ts
@@ -32,11 +32,28 @@ export type UpstreamSource =
       tagPrefix?: string
     }
 
+export type AutoUpdateStrategy =
+  | {
+      kind: "github_release_latest_tag"
+      stripPrefix?: string
+    }
+  | {
+      kind: "git_head_sha"
+      prefix?: string
+      ref: string
+      shaLength?: number
+    }
+  | {
+      kind: "rpm_redirect"
+      sourceUrl?: string
+    }
+
 export type PackageRegistryEntry = {
   id: string
   kind: PackageKind
   homebrewPath: string
   supportsPrCi: boolean
+  autoUpdate: AutoUpdateStrategy
   upstream: UpstreamSource
 }
 

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -65,6 +65,7 @@ test("registry entries expose the required orchestration fields", () => {
     assert.ok(entry.id.length > 0)
     assert.ok(entry.homebrewPath.startsWith("Casks/") || entry.homebrewPath.startsWith("Formula/"))
     assert.ok(typeof entry.supportsPrCi === "boolean")
+    assert.ok(typeof entry.autoUpdate.kind === "string")
     assert.ok(typeof entry.upstream.kind === "string")
   }
 })
@@ -94,4 +95,14 @@ test("auto-update slots cover the expected package set", () => {
       "vscode-insiders-linux",
     ],
   )
+})
+
+test("every auto-updated package declares a version resolution strategy", () => {
+  const registryById = new Map(PACKAGE_REGISTRY.map((entry) => [entry.id, entry]))
+
+  for (const packageId of new Set(AUTO_UPDATE_SLOTS.flatMap((slot) => slot.packageIds))) {
+    const entry = registryById.get(packageId)
+    assert.ok(entry, `missing registry entry for ${packageId}`)
+    assert.ok(entry.autoUpdate, `missing auto-update strategy for ${packageId}`)
+  }
 })

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -66,6 +66,7 @@ test("registry entries expose the required orchestration fields", () => {
     assert.ok(entry.homebrewPath.startsWith("Casks/") || entry.homebrewPath.startsWith("Formula/"))
     assert.ok(typeof entry.supportsPrCi === "boolean")
     assert.ok(typeof entry.autoUpdate.kind === "string")
+    assert.ok(entry.upstream, `missing upstream for ${entry.id}`)
     assert.ok(typeof entry.upstream.kind === "string")
   }
 })

--- a/scripts/prune-package-releases.mjs
+++ b/scripts/prune-package-releases.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process"
+
+function parseArgs(argv) {
+  const args = {}
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (!arg?.startsWith("--")) continue
+
+    const key = arg.slice(2)
+    const value = argv[index + 1]
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`)
+    }
+
+    args[key] = value
+    index += 1
+  }
+
+  return args
+}
+
+function ghJson(args) {
+  return JSON.parse(execFileSync("gh", args, { encoding: "utf8" }))
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const repo = args.repo
+  const packageId = args["package-id"]
+  const currentTag = args["current-tag"]
+  const keep = Number.parseInt(args.keep ?? "3", 10)
+
+  if (!repo || !packageId || !currentTag) {
+    throw new Error(
+      "Usage: prune-package-releases.mjs --repo <owner/name> --package-id <id> --current-tag <tag> [--keep <count>]",
+    )
+  }
+
+  if (!Number.isInteger(keep) || keep < 1) {
+    throw new Error(`--keep must be an integer >= 1, got ${args.keep ?? ""}`)
+  }
+
+  const releases = ghJson([
+    "api",
+    `repos/${repo}/releases?per_page=100`,
+    "--paginate",
+    "--slurp",
+  ]).flat()
+
+  const prefix = `${packageId}-`
+  const matching = releases
+    .filter((release) => typeof release.tag_name === "string" && release.tag_name.startsWith(prefix))
+    .sort((left, right) => {
+      const leftDate = Date.parse(left.published_at ?? left.created_at ?? 0)
+      const rightDate = Date.parse(right.published_at ?? right.created_at ?? 0)
+      return rightDate - leftDate
+    })
+
+  const keepTags = new Set(matching.slice(0, keep).map((release) => release.tag_name))
+  keepTags.add(currentTag)
+
+  const prune = matching.filter((release) => !keepTags.has(release.tag_name))
+
+  if (prune.length === 0) {
+    console.log(`No old ${packageId} releases to prune. Keeping ${keepTags.size} release(s).`)
+    return
+  }
+
+  for (const release of prune) {
+    execFileSync(
+      "gh",
+      ["release", "delete", release.tag_name, "--repo", repo, "--cleanup-tag", "--yes"],
+      { stdio: "inherit" },
+    )
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
This change teaches the tap auto-update workflow to resolve upstream versions before building, so scheduled runs only build packages whose upstream state actually changed. It also prunes older package releases and hardens the T3 Code AppImage extraction path.

## What changed
- added a Dagger `autoUpdateStatus` planning step and package-specific version resolution strategies for every auto-updated package
- updated `tap-auto-update` to skip build and publish entirely when a slot has no upstream changes
- fixed `voxtype` to resolve the latest upstream release tag instead of drifting back to `0.6.4`
- added release pruning so we keep only the newest 3 releases per package
- made `t3-code-linux` discover the extracted desktop file and icon instead of assuming the old filenames
- added a contract test so newly auto-updated packages must declare a version-resolution strategy

## Why
The previous auto-update flow always built first and only discovered no-op updates later, which wasted build and smoke-test time. It also contributed to stale `voxtype` regeneration and excessive release churn.

## Impact
- scheduled workflows should do much less unnecessary work
- `desktop-6h` currently plans to build only `voxtype`
- `t3-daily` currently plans to build `t3code-cli-main` and `t3-code-linux`
- older package releases are cleaned up automatically after publish

## Validation
- `npm test --prefix dagger/tap-pipeline`
- `dagger -m ./dagger/tap-pipeline call auto-update-status --slot-id=desktop-6h`
- `dagger -m ./dagger/tap-pipeline call auto-update-status --slot-id=t3-daily`
- verified all scheduled slots with `dagger ... auto-update-status`
- locally verified the latest T3 AppImage extracts the expected desktop/icon assets
