### PR TITLE
chore: update workflow action refs

### DIFF
--- a/.github/workflows/tap-auto-update.yml
+++ b/.github/workflows/tap-auto-update.yml
@@ -142,7 +142,7 @@ jobs:
           --package-id="${{ matrix.package_id }}"
 
     - name: Upload release bundle artifact
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: release-bundle-${{ matrix.package_id }}
         path: ${{ runner.temp }}/bundle


### PR DESCRIPTION
## Automated RCC Maintenance

This PR updates allowed GitHub Actions workflow references and refreshes the local RCC maintenance robot.

### Changed files


