### PR TITLE
[codex] Fix fizzy-popper Homebrew version ordering

### DIFF
--- a/Formula/fizzy-popper-self-hosted.rb
+++ b/Formula/fizzy-popper-self-hosted.rb
@@ -3,6 +3,7 @@ class FizzyPopperSelfHosted < Formula
   homepage "https://github.com/joshyorko/fizzy-popper/tree/self-hosted"
   url "https://github.com/joshyorko/homebrew-tools/releases/download/fizzy-popper-self-hosted-selfhosted.d08b71dff98d/fizzy-popper-self-hosted-selfhosted.d08b71dff98d.tar.gz"
   version "selfhosted.d08b71dff98d"
+  version_scheme 1
   sha256 "8d9ba611b7d5eba1c6ee22804e0d2a58387464e8f2d200a72be6891ab2b7cfc0"
   license "MIT"
 

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -5,6 +5,7 @@ import {
   packageSummaries,
   parseAutoUpdateSlotId,
   packagesForAutoUpdateSlot as slotPackages,
+  formatGitHeadVersion,
   releaseMetadataForPackage,
 } from "./library.js"
 import { rewriteCaskUrl } from "./cask-render.js"
@@ -154,6 +155,18 @@ type FizzyPopperSelfHostedBuild = {
   commit: string
   container: Container
   version: string
+}
+
+type GitCommitApiResponse = {
+  sha: string
+  commit?: {
+    author?: {
+      date?: string
+    }
+    committer?: {
+      date?: string
+    }
+  }
 }
 
 type VscodeBuild = {
@@ -751,9 +764,23 @@ export class TapPipeline {
     ref: string,
     version?: string,
   ): Promise<FizzyPopperSelfHostedBuild> {
-    const upstreamRef = dag.git("https://github.com/joshyorko/fizzy-popper").ref(ref)
+    const entry = this.packageEntry("fizzy-popper-self-hosted")
+
+    if (entry.upstream.kind !== "git" || entry.autoUpdate.kind !== "git_head_sha") {
+      throw new Error("Expected fizzy-popper-self-hosted to use a git-head auto-update strategy")
+    }
+
+    const resolvedGitHead = version && version.length > 0
+      ? undefined
+      : await this.resolveGitHeadVersion(entry.upstream.repo, ref, entry.autoUpdate)
+    const upstreamRef = dag.git(entry.upstream.repo).ref(resolvedGitHead?.commit ?? ref)
     const commit = await upstreamRef.commit()
-    const resolvedVersion = version && version.length > 0 ? version : `selfhosted.${commit.slice(0, 12)}`
+    const resolvedVersion = version && version.length > 0 ? version : resolvedGitHead?.version
+
+    if (!resolvedVersion) {
+      throw new Error("Failed to resolve fizzy-popper-self-hosted version")
+    }
+
     const assetName = `fizzy-popper-self-hosted-${resolvedVersion}.tar.gz`
     const artifactPath = `/tmp/${assetName}`
 
@@ -997,6 +1024,30 @@ export class TapPipeline {
     return JSON.parse(output)
   }
 
+  private async resolveGitHeadVersion(
+    repo: string,
+    ref: string,
+    options: {
+      includeCommitDate?: boolean
+      prefix?: string
+      shaLength?: number
+    },
+  ): Promise<{ commit: string, version: string }> {
+    const commit = await this.fetchJson(`${githubApiRepoUrl(repo)}/commits/${ref}`) as GitCommitApiResponse
+    const committedAt = commit.commit?.committer?.date ?? commit.commit?.author?.date
+
+    return {
+      commit: commit.sha,
+      version: formatGitHeadVersion({
+        committedAt,
+        includeCommitDate: options.includeCommitDate,
+        prefix: options.prefix,
+        sha: commit.sha,
+        shaLength: options.shaLength,
+      }),
+    }
+  }
+
   private async resolveVscodeMetadata(sourceUrl?: string): Promise<{
     resolvedUrl: string
     packageVersion: string
@@ -1066,11 +1117,7 @@ export class TapPipeline {
         }
 
         const ref = entry.autoUpdate.ref
-        const commit = await this.fetchJson(`${githubApiRepoUrl(entry.upstream.repo)}/commits/${ref}`) as {
-          sha: string
-        }
-        const shaLength = entry.autoUpdate.shaLength ?? 12
-        return `${entry.autoUpdate.prefix ?? ""}${commit.sha.slice(0, shaLength)}`
+        return (await this.resolveGitHeadVersion(entry.upstream.repo, ref, entry.autoUpdate)).version
       }
       case "rpm_redirect": {
         const sourceUrl = entry.autoUpdate.sourceUrl

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -2,6 +2,38 @@ import { readFileSync } from "node:fs"
 
 import type { AutoUpdateSlot, AutoUpdateSlotId, PackageRegistryEntry, ReleaseMetadata } from "./types.js"
 
+type GitHeadVersionInput = {
+  committedAt?: string
+  includeCommitDate?: boolean
+  prefix?: string
+  sha: string
+  shaLength?: number
+}
+
+function compactUtcTimestamp(value: string): string {
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid commit date: ${value}`)
+  }
+
+  return date.toISOString().replace(/\D/g, "").slice(0, 14)
+}
+
+export function formatGitHeadVersion(input: GitHeadVersionInput): string {
+  const shortSha = input.sha.slice(0, input.shaLength ?? 12)
+
+  if (!input.includeCommitDate) {
+    return `${input.prefix ?? ""}${shortSha}`
+  }
+
+  if (!input.committedAt) {
+    throw new Error("A commit date is required for timestamped git-head versions")
+  }
+
+  return `${input.prefix ?? ""}${compactUtcTimestamp(input.committedAt)}.${shortSha}`
+}
+
 export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
   {
     id: "t3code-cli-main",
@@ -47,6 +79,7 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
       ref: "self-hosted",
       prefix: "selfhosted.",
       shaLength: 12,
+      includeCommitDate: true,
     },
     upstream: {
       kind: "git",

--- a/dagger/tap-pipeline/src/types.ts
+++ b/dagger/tap-pipeline/src/types.ts
@@ -44,6 +44,7 @@ export type AutoUpdateStrategy =
       prefix?: string
       ref: string
       shaLength?: number
+      includeCommitDate?: boolean
     }
   | {
       kind: "rpm_redirect"

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -1,7 +1,8 @@
 import test from "node:test"
 import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
 
-import { AUTO_UPDATE_SLOTS, PACKAGE_REGISTRY, releaseMetadataForPackage } from "../src/library.ts"
+import { AUTO_UPDATE_SLOTS, PACKAGE_REGISTRY, formatGitHeadVersion, releaseMetadataForPackage } from "../src/library.ts"
 
 const REQUIRED_RELEASE_FIELDS = [
   "package",
@@ -110,4 +111,42 @@ test("every auto-updated package declares a version resolution strategy", () => 
     assert.ok(entry, `missing registry entry for ${packageId}`)
     assert.ok(entry.autoUpdate, `missing auto-update strategy for ${packageId}`)
   }
+})
+
+test("timestamped git-head versions sort by commit time before sha", () => {
+  const older = formatGitHeadVersion({
+    committedAt: "2026-04-25T20:00:00Z",
+    includeCommitDate: true,
+    prefix: "selfhosted.",
+    sha: "f641c5c86889abcdef",
+    shaLength: 12,
+  })
+  const newer = formatGitHeadVersion({
+    committedAt: "2026-04-26T20:00:00Z",
+    includeCommitDate: true,
+    prefix: "selfhosted.",
+    sha: "d08b71dff98dabcdef",
+    shaLength: 12,
+  })
+
+  assert.equal(older, "selfhosted.20260425200000.f641c5c86889")
+  assert.equal(newer, "selfhosted.20260426200000.d08b71dff98d")
+  assert.equal(newer > older, true)
+})
+
+test("fizzy-popper self-hosted opts into timestamped git-head versions", () => {
+  const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "fizzy-popper-self-hosted")
+
+  assert.ok(entry)
+  assert.equal(entry.autoUpdate.kind, "git_head_sha")
+
+  if (entry.autoUpdate.kind === "git_head_sha") {
+    assert.equal(entry.autoUpdate.includeCommitDate, true)
+  }
+})
+
+test("fizzy-popper self-hosted formula bumps the Homebrew version scheme", () => {
+  const formula = readFileSync(new URL("../../../Formula/fizzy-popper-self-hosted.rb", import.meta.url), "utf8")
+
+  assert.match(formula, /^\s*version_scheme 1$/m)
 })


### PR DESCRIPTION
## Summary
- make fizzy-popper self-hosted auto-update versions timestamped by source commit date before the short SHA
- reuse that resolved git-head version in both update detection and artifact builds
- add `version_scheme 1` so Homebrew upgrades cleanly from the older SHA-only version scheme

## Root Cause
Homebrew compares formula versions lexically enough that raw SHA snapshots are not monotonic. The installed `selfhosted.f641...` sorted newer than the tap's `selfhosted.d08...`, so `brew upgrade` saw no upgrade even after `brew update` fetched the formula change.

## Validation
- `npm test --prefix dagger/tap-pipeline`
- `dagger -m ./dagger/tap-pipeline call auto-update-status --slot-id=fizzy-daily`
- `dagger -m ./dagger/tap-pipeline call ci-check --package-id=fizzy-popper-self-hosted`
- `brew ruby` comparison confirms scheme 1 timestamped version is newer than old scheme 0 SHA-only version
