### PR TITLE
Add fizzy-symphony source build

### DIFF
--- a/Formula/fizzy-symphony.rb
+++ b/Formula/fizzy-symphony.rb
@@ -1,0 +1,38 @@
+class FizzySymphony < Formula
+  desc "Fizzy-backed Symphony daemon built from joshyorko/fizzy-symphony main"
+  homepage "https://github.com/joshyorko/fizzy-symphony"
+  url "https://github.com/joshyorko/homebrew-tools/releases/download/fizzy-symphony-main.20260501171603.ad69b0916ef7/fizzy-symphony-main.20260501171603.ad69b0916ef7.tar.gz"
+  version "main.20260501171603.ad69b0916ef7"
+  sha256 "1b067f69f803c25d9fe91a019e8c46997b16bad5f2b1b95e7322a8d4b23d0cff"
+  license :cannot_represent
+
+  livecheck do
+    skip "Updated by the tap's GitHub Actions workflow."
+  end
+
+  depends_on :linux
+  depends_on "node"
+
+  def install
+    libexec.install Dir["*"]
+
+    (bin/"fizzy-symphony").write <<~SH
+      #!/bin/bash
+      exec "#{Formula["node"].opt_bin}/node" "#{libexec}/bin/fizzy-symphony.js" "$@"
+    SH
+  end
+
+  def caveats
+    <<~EOS
+      This formula tracks joshyorko/fizzy-symphony main snapshots.
+
+      The tap release version identifies the source commit snapshot. The Node package
+      inside the artifact currently keeps fizzy-symphony's own package version.
+    EOS
+  end
+
+  test do
+    output = shell_output("#{bin}/fizzy-symphony")
+    assert_match "fizzy-symphony start", output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ An automation runtime for creating isolated, reproducible environments. Fork of 
 | `brew install --cask joshyorko/tools/vscode-insiders-linux` | Install VS Code Insiders (Linux) |
 | `brew install joshyorko/tools/t3code-cli-main` | Install T3 Code CLI from `main` |
 | `brew install joshyorko/tools/fizzy-cli-master` | Install Fizzy CLI from upstream `master` |
+| `brew install joshyorko/tools/fizzy-symphony` | Install Fizzy Symphony from `main` |
 | `brew install joshyorko/tools/eitype` | Install Eitype |
 | `brew install joshyorko/tools/voxtype` | Install Voxtype |
 | `brew upgrade --cask joshyorko/tools/rcc` | Upgrade to latest |
@@ -254,6 +255,45 @@ That smoke test exercises the real delivery path:
 - wrap the locally built package into a Homebrew-ready tarball with vendored runtime dependencies
 - install the formula through Linuxbrew in-container
 - run `brew test` and `fizzy-popper --help`
+
+### Fizzy Symphony (Main Formula)
+
+Fizzy Symphony packaged for Linux Homebrew from `joshyorko/fizzy-symphony` `main`.
+The tap builds the Node package from source with Dagger, vendors runtime dependencies into
+an immutable tarball, and installs the CLI as `fizzy-symphony`.
+
+> [!NOTE]
+> Use the full tap path to make the source snapshot explicit:
+> ```bash
+> brew install joshyorko/tools/fizzy-symphony
+> ```
+
+```bash
+brew install joshyorko/tools/fizzy-symphony
+fizzy-symphony
+fizzy-symphony status
+```
+
+Update flow:
+- the `fizzy-daily` auto-update slot tracks `joshyorko/fizzy-symphony@main`
+- to publish or refresh the immutable release asset on demand, run the Tap Manual `release`
+  workflow with `package_id=fizzy-symphony`
+- if you want to freeze to a specific snapshot, pin `upstream.ref` for
+  `fizzy-symphony` in `dagger/tap-pipeline/src/library.ts` to a commit SHA and run
+  that same manual release workflow
+
+The tap also includes a reusable Dagger smoke test for this packaging path:
+
+```bash
+dagger -m ./dagger/fizzy-symphony-smoke call smoke-test --tap=.
+```
+
+That smoke test exercises the real delivery path:
+- build `joshyorko/fizzy-symphony@main` inside the tap pipeline
+- run the upstream package gates (`npm test`, optional `npm run build`, `npm pack`)
+- wrap the locally built package into a Homebrew-ready tarball with vendored runtime dependencies
+- install the formula through Linuxbrew in-container
+- run `brew test` and `fizzy-symphony`
 
 ### Voxtype (Formula)
 

--- a/dagger/fizzy-symphony-smoke/dagger.json
+++ b/dagger/fizzy-symphony-smoke/dagger.json
@@ -1,0 +1,7 @@
+{
+  "name": "fizzy-symphony-smoke",
+  "engineVersion": "v0.20.6",
+  "sdk": {
+    "source": "typescript"
+  }
+}

--- a/dagger/fizzy-symphony-smoke/package.json
+++ b/dagger/fizzy-symphony-smoke/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/dagger/fizzy-symphony-smoke/src/index.ts
+++ b/dagger/fizzy-symphony-smoke/src/index.ts
@@ -1,0 +1,124 @@
+import { dag, CacheSharingMode, Container, Directory, File, object, func } from "@dagger.io/dagger"
+
+const UPSTREAM_REPO = "https://github.com/joshyorko/fizzy-symphony"
+const NODE_IMAGE = "node:25-bookworm"
+const BREW_IMAGE = "homebrew/brew:latest"
+const FORMULA_PATH = "Formula/fizzy-symphony.rb"
+
+@object()
+export class FizzySymphonySmoke {
+  private baseContainer(): Container {
+    return dag
+      .container()
+      .from(NODE_IMAGE)
+      .withMountedCache(
+        "/root/.npm",
+        dag.cacheVolume("fizzy-symphony-smoke-npm-cache"),
+        { sharing: CacheSharingMode.Locked },
+      )
+      .withExec([
+        "bash",
+        "-lc",
+        "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates tar && rm -rf /var/lib/apt/lists/*",
+      ])
+  }
+
+  private async artifactBuild(tap: Directory, ref: string, version?: string): Promise<{
+    artifactPath: string
+    assetName: string
+    commit: string
+    container: Container
+    version: string
+  }> {
+    const upstreamRef = dag.git(UPSTREAM_REPO).ref(ref)
+    const commit = await upstreamRef.commit()
+    const resolvedVersion = version && version.length > 0 ? version : `main.${commit.slice(0, 12)}`
+    const assetName = `fizzy-symphony-${resolvedVersion}.tar.gz`
+    const artifactPath = `/tmp/${assetName}`
+
+    const container = this.baseContainer()
+      .withDirectory("/tap", tap)
+      .withDirectory("/upstream", upstreamRef.tree({ discardGitDir: true }))
+      .withWorkdir("/upstream")
+      .withExec(["npm", "ci"])
+      .withExec(["npm", "test"])
+      .withExec(["npm", "run", "build", "--if-present"])
+      .withExec(["npm", "pack", "--pack-destination", "/tmp"])
+      .withExec([
+        "node",
+        "/tap/scripts/package-fizzy-symphony.mjs",
+        "--upstream-dir",
+        "/upstream",
+        "--npm-pack-dir",
+        "/tmp",
+        "--version",
+        resolvedVersion,
+        "--output",
+        artifactPath,
+      ])
+
+    return {
+      artifactPath,
+      assetName,
+      commit,
+      container,
+      version: resolvedVersion,
+    }
+  }
+
+  @func()
+  async packageArtifact(tap: Directory, ref = "main", version = ""): Promise<File> {
+    const build = await this.artifactBuild(tap, ref, version)
+    return build.container.file(build.artifactPath)
+  }
+
+  @func()
+  async smokeTest(tap: Directory, ref = "main", version = ""): Promise<string> {
+    const build = await this.artifactBuild(tap, ref, version)
+    const sha256 = (
+      await build.container.withExec(["sha256sum", build.artifactPath]).stdout()
+    ).trim().split(/\s+/)[0]
+    const formulaContents = await tap.file(FORMULA_PATH).contents()
+    const updatedFormula = formulaContents
+      .replace(/url ".*"/, `url "file:///artifacts/${build.assetName}"`)
+      .replace(/version ".*"/, `version "${build.version}"`)
+      .replace(/sha256 ".*"/, `sha256 "${sha256}"`)
+    const smokeTap = tap.withFile(FORMULA_PATH, dag.file("fizzy-symphony.rb", updatedFormula))
+    const output = await dag
+      .container()
+      .from(BREW_IMAGE)
+      .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
+      .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
+      .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
+      .withDirectory("/tap", smokeTap)
+      .withFile(`/artifacts/${build.assetName}`, build.container.file(build.artifactPath))
+      .withExec([
+        "bash",
+        "-lc",
+        [
+          "set -euo pipefail",
+          "repo=$(brew --repository)",
+          "tap_dir=\"$repo/Library/Taps/test/homebrew-tap\"",
+          `echo "upstream_commit=${build.commit}"`,
+          `echo "packaged_version=${build.version}"`,
+          `echo "artifact_sha256=${sha256}"`,
+          "mkdir -p \"$tap_dir/Formula\"",
+          "cp /tap/Formula/fizzy-symphony.rb \"$tap_dir/Formula/\"",
+          "brew install test/tap/fizzy-symphony",
+          "test -x \"$(brew --prefix)/bin/fizzy-symphony\"",
+          "brew test test/tap/fizzy-symphony",
+          "echo '--- package contents ---'",
+          `tar -tzf /artifacts/${build.assetName} | sed -n '1,20p'`,
+          "echo '--- fizzy-symphony usage ---'",
+          "fizzy-symphony",
+        ].join("\n"),
+      ])
+      .stdout()
+
+    if (!output.includes("Usage:") || !output.includes("fizzy-symphony start")) {
+      throw new Error(`Smoke test did not produce expected fizzy-symphony usage output:\n${output}`)
+    }
+
+    return output
+  }
+}

--- a/dagger/tap-pipeline/auto-update-slots.json
+++ b/dagger/tap-pipeline/auto-update-slots.json
@@ -31,7 +31,7 @@
   },
   {
     "id": "fizzy-daily",
-    "description": "Daily refresh for Fizzy CLI upstream master and the fizzy-popper self-hosted fork.",
-    "packageIds": ["fizzy-cli-master", "fizzy-popper-self-hosted"]
+    "description": "Daily refresh for Fizzy CLI upstream master, fizzy-popper self-hosted, and fizzy-symphony main.",
+    "packageIds": ["fizzy-cli-master", "fizzy-popper-self-hosted", "fizzy-symphony"]
   }
 ]

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -14,6 +14,7 @@ import { renderGithubApiFetchScript } from "./github-api.js"
 const TAP_DIR = "/tap"
 const BREW_IMAGE = "homebrew/brew:latest"
 const NODE_IMAGE = "node:24-bookworm"
+const NODE_25_IMAGE = "node:25-bookworm"
 const GO_IMAGE = "golang:1.26-bookworm"
 const RUST_IMAGE = "rust:1-bookworm"
 const TAP_REPOSITORY = "joshyorko/homebrew-tools"
@@ -78,6 +79,11 @@ function tapStagingCommands(packageId: string): string[] {
       return [
         "mkdir -p \"$tap_dir/Formula\"",
         "cp /tap/Formula/fizzy-popper-self-hosted.rb \"$tap_dir/Formula/\"",
+      ]
+    case "fizzy-symphony":
+      return [
+        "mkdir -p \"$tap_dir/Formula\"",
+        "cp /tap/Formula/fizzy-symphony.rb \"$tap_dir/Formula/\"",
       ]
     case "t3-code-linux":
       return [
@@ -150,6 +156,14 @@ type FizzyBuild = {
 }
 
 type FizzyPopperSelfHostedBuild = {
+  artifactPath: string
+  assetName: string
+  commit: string
+  container: Container
+  version: string
+}
+
+type FizzySymphonyBuild = {
   artifactPath: string
   assetName: string
   commit: string
@@ -365,6 +379,8 @@ export class TapPipeline {
         return `fizzy-cli-master-${version}`
       case "fizzy-popper-self-hosted":
         return `fizzy-popper-self-hosted-${version}`
+      case "fizzy-symphony":
+        return `fizzy-symphony-${version}`
       case "t3-code-linux":
         return `t3-code-linux-${version}`
       case "vscode-insiders-linux":
@@ -607,6 +623,29 @@ export class TapPipeline {
     })
   }
 
+  private fizzySymphonyReleaseMetadata(
+    build: FizzySymphonyBuild,
+    sha256: string,
+  ): Record<string, unknown> {
+    return releaseMetadataForPackage("fizzy-symphony", {
+      version: build.version,
+      releaseTag: `fizzy-symphony-${build.version}`,
+      assetName: build.assetName,
+      artifactSha256: sha256,
+      downloadUrl: `https://github.com/${TAP_REPOSITORY}/releases/download/fizzy-symphony-${build.version}/${build.assetName}`,
+      releaseTitle: `fizzy-symphony ${build.version}`,
+      releaseNotes: `CLI snapshot from joshyorko/fizzy-symphony@${build.commit} (main)`,
+      commitMessage: `Update fizzy-symphony formula to ${build.version}`,
+      upstream: {
+        kind: "git",
+        repo: "https://github.com/joshyorko/fizzy-symphony",
+        ref: "main",
+        version: build.version,
+        commit: build.commit,
+      },
+    })
+  }
+
   private t3CodeReleaseMetadata(build: T3CodeBuild): Record<string, unknown> {
     return releaseMetadataForPackage("t3-code-linux", {
       version: build.version,
@@ -823,6 +862,73 @@ export class TapPipeline {
       .withExec([
         "node",
         "/tap/scripts/package-fizzy-popper-self-hosted.mjs",
+        "--upstream-dir",
+        "/upstream",
+        "--npm-pack-dir",
+        "/tmp",
+        "--version",
+        resolvedVersion,
+        "--output",
+        artifactPath,
+      ])
+
+    return {
+      artifactPath,
+      assetName,
+      commit,
+      container,
+      version: resolvedVersion,
+    }
+  }
+
+  private async buildFizzySymphonyArtifact(
+    tap: Directory,
+    ref: string,
+    version?: string,
+  ): Promise<FizzySymphonyBuild> {
+    const entry = this.packageEntry("fizzy-symphony")
+
+    if (entry.upstream.kind !== "git" || entry.autoUpdate.kind !== "git_head_sha") {
+      throw new Error("Expected fizzy-symphony to use a git-head auto-update strategy")
+    }
+
+    const resolvedGitHead = version && version.length > 0
+      ? undefined
+      : await this.resolveGitHeadVersion(entry.upstream.repo, ref, entry.autoUpdate)
+    const upstreamRef = dag.git(entry.upstream.repo).ref(resolvedGitHead?.commit ?? ref)
+    const commit = await upstreamRef.commit()
+    const resolvedVersion = version && version.length > 0 ? version : resolvedGitHead?.version
+
+    if (!resolvedVersion) {
+      throw new Error("Failed to resolve fizzy-symphony version")
+    }
+
+    const assetName = `fizzy-symphony-${resolvedVersion}.tar.gz`
+    const artifactPath = `/tmp/${assetName}`
+
+    const container = dag
+      .container()
+      .from(NODE_25_IMAGE)
+      .withMountedCache(
+        "/root/.npm",
+        dag.cacheVolume("tap-pipeline-fizzy-symphony-npm-cache"),
+        { sharing: CacheSharingMode.Locked },
+      )
+      .withExec([
+        "bash",
+        "-lc",
+        "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates tar && rm -rf /var/lib/apt/lists/*",
+      ])
+      .withDirectory("/tap", tap)
+      .withDirectory("/upstream", upstreamRef.tree({ discardGitDir: true }))
+      .withWorkdir("/upstream")
+      .withExec(["npm", "ci"])
+      .withExec(["npm", "test"])
+      .withExec(["npm", "run", "build", "--if-present"])
+      .withExec(["npm", "pack", "--pack-destination", "/tmp"])
+      .withExec([
+        "node",
+        "/tap/scripts/package-fizzy-symphony.mjs",
         "--upstream-dir",
         "/upstream",
         "--npm-pack-dir",
@@ -1740,6 +1846,44 @@ export class TapPipeline {
           ])
           .stdout()
       }
+      case "fizzy-symphony": {
+        const build = await this.buildFizzySymphonyArtifact(tap, "main")
+        const sha256 = (
+          await build.container.withExec(["sha256sum", build.artifactPath]).stdout()
+        ).trim().split(/\s+/)[0]
+        const formulaContents = await tap.file("Formula/fizzy-symphony.rb").contents()
+        const updatedFormula = formulaContents
+          .replace(/url ".*"/, `url "file:///artifacts/${build.assetName}"`)
+          .replace(/version ".*"/, `version "${build.version}"`)
+          .replace(/sha256 ".*"/, `sha256 "${sha256}"`)
+        const smokeTap = tap.withFile(
+          "Formula/fizzy-symphony.rb",
+          dag.file("fizzy-symphony.rb", updatedFormula),
+        )
+
+        return dag
+          .container()
+          .from(BREW_IMAGE)
+          .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
+          .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
+          .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
+          .withDirectory("/tap", smokeTap)
+          .withFile(`/artifacts/${build.assetName}`, build.container.file(build.artifactPath))
+          .withExec([
+            "bash",
+            "-lc",
+            [
+              "set -euo pipefail",
+              "repo=$(brew --repository)",
+              "tap_dir=\"$repo/Library/Taps/test/homebrew-tap\"",
+              ...tapStagingCommands("fizzy-symphony"),
+              "brew install test/tap/fizzy-symphony",
+              "brew test test/tap/fizzy-symphony",
+              "fizzy-symphony",
+            ].join("\n"),
+          ])
+          .stdout()
+      }
       case "t3-code-linux": {
         const build = await this.buildT3CodeArtifact()
         const caskContents = await tap.file("Casks/t3-code-linux.rb").contents()
@@ -1974,6 +2118,13 @@ export class TapPipeline {
         ).trim().split(/\s+/)[0]
         return json(this.fizzyPopperSelfHostedReleaseMetadata(build, sha256))
       }
+      case "fizzy-symphony": {
+        const build = await this.buildFizzySymphonyArtifact(tap, "main")
+        const sha256 = (
+          await build.container.withExec(["sha256sum", build.artifactPath]).stdout()
+        ).trim().split(/\s+/)[0]
+        return json(this.fizzySymphonyReleaseMetadata(build, sha256))
+      }
       case "t3-code-linux": {
         const build = await this.buildT3CodeArtifact()
         return json(this.t3CodeReleaseMetadata(build))
@@ -2116,6 +2267,27 @@ export class TapPipeline {
           .withFile(
             "homebrew/fizzy-popper-self-hosted.rb",
             dag.file("fizzy-popper-self-hosted.rb", updatedFormula),
+          )
+          .withFile("release.json", dag.file("release.json", json(release)))
+          .withFile("ci.log", dag.file("ci.log", ciLog))
+      }
+      case "fizzy-symphony": {
+        const build = await this.buildFizzySymphonyArtifact(tap, "main")
+        const sha256 = (
+          await build.container.withExec(["sha256sum", build.artifactPath]).stdout()
+        ).trim().split(/\s+/)[0]
+        const release = this.fizzySymphonyReleaseMetadata(build, sha256)
+        const formulaContents = await tap.file("Formula/fizzy-symphony.rb").contents()
+        const updatedFormula = formulaContents
+          .replace(/url ".*"/, `url "${String(release.download_url)}"`)
+          .replace(/version ".*"/, `version "${build.version}"`)
+          .replace(/sha256 ".*"/, `sha256 "${sha256}"`)
+
+        return dag.directory()
+          .withFile(`artifacts/${build.assetName}`, build.container.file(build.artifactPath))
+          .withFile(
+            "homebrew/fizzy-symphony.rb",
+            dag.file("fizzy-symphony.rb", updatedFormula),
           )
           .withFile("release.json", dag.file("release.json", json(release)))
           .withFile("ci.log", dag.file("ci.log", ciLog))

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -88,6 +88,24 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     },
   },
   {
+    id: "fizzy-symphony",
+    kind: "source_build_node_formula",
+    homebrewPath: "Formula/fizzy-symphony.rb",
+    supportsPrCi: true,
+    autoUpdate: {
+      kind: "git_head_sha",
+      ref: "main",
+      prefix: "main.",
+      shaLength: 12,
+      includeCommitDate: true,
+    },
+    upstream: {
+      kind: "git",
+      repo: "https://github.com/joshyorko/fizzy-symphony",
+      ref: "main",
+    },
+  },
+  {
     id: "vscode-insiders-linux",
     kind: "rpm_repack_cask",
     homebrewPath: "Casks/vscode-insiders-linux.rb",
@@ -215,6 +233,14 @@ const CHANGED_PATHS: Array<[string, string[]]> = [
       "Formula/fizzy-popper-self-hosted.rb",
       "scripts/package-fizzy-popper-self-hosted.mjs",
       "dagger/fizzy-popper-self-hosted-smoke/",
+    ],
+  ],
+  [
+    "fizzy-symphony",
+    [
+      "Formula/fizzy-symphony.rb",
+      "scripts/package-fizzy-symphony.mjs",
+      "dagger/fizzy-symphony-smoke/",
     ],
   ],
   [

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -94,6 +94,7 @@ test("auto-update slots cover the expected package set", () => {
       "eitype",
       "fizzy-cli-master",
       "fizzy-popper-self-hosted",
+      "fizzy-symphony",
       "rcc",
       "t3-code-linux",
       "t3code-cli-main",
@@ -136,6 +137,17 @@ test("timestamped git-head versions sort by commit time before sha", () => {
 
 test("fizzy-popper self-hosted opts into timestamped git-head versions", () => {
   const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "fizzy-popper-self-hosted")
+
+  assert.ok(entry)
+  assert.equal(entry.autoUpdate.kind, "git_head_sha")
+
+  if (entry.autoUpdate.kind === "git_head_sha") {
+    assert.equal(entry.autoUpdate.includeCommitDate, true)
+  }
+})
+
+test("fizzy-symphony opts into timestamped git-head versions", () => {
+  const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "fizzy-symphony")
 
   assert.ok(entry)
   assert.equal(entry.autoUpdate.kind, "git_head_sha")

--- a/dagger/tap-pipeline/tests/planner.test.ts
+++ b/dagger/tap-pipeline/tests/planner.test.ts
@@ -48,6 +48,7 @@ test("every PR-enabled package has a changed-path trigger", () => {
     "t3code-cli-main": "Formula/t3code-cli-main.rb",
     "fizzy-cli-master": "Formula/fizzy-cli-master.rb",
     "fizzy-popper-self-hosted": "Formula/fizzy-popper-self-hosted.rb",
+    "fizzy-symphony": "Formula/fizzy-symphony.rb",
     "vscode-insiders-linux": "Casks/vscode-insiders-linux.rb",
     voxtype: "Formula/voxtype.rb",
     eitype: "Formula/eitype.rb",

--- a/scripts/package-fizzy-symphony.mjs
+++ b/scripts/package-fizzy-symphony.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs"
+import { execFileSync } from "node:child_process"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+
+function parseArgs(argv) {
+  const args = {}
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (!arg?.startsWith("--")) continue
+
+    const key = arg.slice(2)
+    const value = argv[index + 1]
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`)
+    }
+
+    args[key] = value
+    index += 1
+  }
+
+  return args
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+function normalizeBinEntry(binEntry) {
+  if (typeof binEntry !== "string" || binEntry.length === 0) {
+    throw new Error('Expected package.json to define a string bin entry for "fizzy-symphony"')
+  }
+
+  return binEntry.startsWith("./") ? binEntry.slice(2) : binEntry
+}
+
+function findNpmPackTarball(packDir) {
+  const matches = readdirSync(packDir)
+    .filter((entry) => /^fizzy-symphony-.*\.tgz$/.test(entry))
+    .sort()
+
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one fizzy-symphony npm tarball in ${packDir}, found ${matches.length}`)
+  }
+
+  return join(packDir, matches[0])
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const upstreamDirArg = args["upstream-dir"]
+  const npmPackDirArg = args["npm-pack-dir"]
+  const version = args.version
+  const outputPathArg = args.output
+
+  if (!upstreamDirArg || !npmPackDirArg || !version || !outputPathArg) {
+    throw new Error(
+      "Usage: package-fizzy-symphony.mjs --upstream-dir <dir> --npm-pack-dir <dir> --version <version> --output <tar.gz>",
+    )
+  }
+
+  const upstreamDir = resolve(upstreamDirArg)
+  const npmPackDir = resolve(npmPackDirArg)
+  const outputPath = resolve(outputPathArg)
+  const sourcePackageJson = readJson(join(upstreamDir, "package.json"))
+  const cliEntryRelativePath = normalizeBinEntry(sourcePackageJson.bin?.["fizzy-symphony"])
+  const npmPackTarball = findNpmPackTarball(npmPackDir)
+  const stageRoot = mkdtempSync(join(tmpdir(), "fizzy-symphony-"))
+  const packageDir = join(stageRoot, "package")
+
+  try {
+    mkdirSync(packageDir, { recursive: true })
+
+    execFileSync("tar", ["-xzf", npmPackTarball, "--strip-components=1", "-C", packageDir], {
+      stdio: "inherit",
+    })
+    cpSync(join(upstreamDir, "package-lock.json"), join(packageDir, "package-lock.json"))
+
+    if (!existsSync(join(packageDir, cliEntryRelativePath))) {
+      throw new Error(`Missing CLI entrypoint at ${join(packageDir, cliEntryRelativePath)}`)
+    }
+
+    if (!existsSync(join(packageDir, "src"))) {
+      throw new Error(`Missing runtime source at ${join(packageDir, "src")}`)
+    }
+
+    execFileSync("npm", ["ci", "--omit=dev"], {
+      cwd: packageDir,
+      stdio: "inherit",
+    })
+
+    mkdirSync(dirname(outputPath), { recursive: true })
+    execFileSync(
+      "tar",
+      [
+        "--sort=name",
+        "--mtime=@0",
+        "--owner=0",
+        "--group=0",
+        "--numeric-owner",
+        "--use-compress-program=gzip -n",
+        "-cf",
+        outputPath,
+        "-C",
+        packageDir,
+        ".",
+      ],
+      { stdio: "inherit" },
+    )
+
+    console.log(outputPath)
+  } finally {
+    rmSync(stageRoot, { recursive: true, force: true })
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
- Add the Linuxbrew fizzy-symphony formula and source packaging script.
- Wire fizzy-symphony into the Dagger tap pipeline, release metadata, PR CI triggers, and auto-update slot.
- Add a reusable Dagger smoke module and README install notes.

## Checks
- npm test --prefix dagger/tap-pipeline
- dagger -m ./dagger/tap-pipeline call ci-check --package-id=fizzy-symphony
- git diff --check