### PR TITLE
[codex] Fix t3code runtime version packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Use the Node packaging scripts only when iterating on artifacts directly:
 
 ```bash
 node scripts/package-vscode-insiders-linux.mjs --source-rpm /tmp/source.rpm --output /tmp/pkg.tar.gz
-node scripts/package-t3code-cli-main.mjs --upstream-dir /tmp/t3code --version smoke.test --output /tmp/pkg.tar.gz
+node scripts/package-t3code-cli-main.mjs --upstream-dir /tmp/t3code --version main.test --output /tmp/pkg.tar.gz
 ```
 
 ## Coding Style & Naming Conventions

--- a/Formula/t3code-cli-main.rb
+++ b/Formula/t3code-cli-main.rb
@@ -5,6 +5,7 @@ class T3codeCliMain < Formula
   version "smoke.a74ed8ed32c2"
   sha256 "bd28c9f0f5ed73d6c469e4cd8fa5fe6cf7458d409bbdd2d3245a201f511358a6"
   license "MIT"
+  version_scheme 1
 
   livecheck do
     skip "Updated by the tap's GitHub Actions workflow."

--- a/dagger/t3code-cli-main-smoke/src/index.ts
+++ b/dagger/t3code-cli-main-smoke/src/index.ts
@@ -37,7 +37,7 @@ export class T3CodeCliMainSmoke {
   }> {
     const upstreamRef = dag.git(UPSTREAM_REPO).ref(ref)
     const commit = await upstreamRef.commit()
-    const resolvedVersion = version && version.length > 0 ? version : `smoke.${commit.slice(0, 12)}`
+    const resolvedVersion = version && version.length > 0 ? version : `main.${commit.slice(0, 12)}`
     const assetName = `t3code-cli-main-${resolvedVersion}.tar.gz`
     const artifactPath = `/tmp/${assetName}`
 
@@ -45,18 +45,6 @@ export class T3CodeCliMainSmoke {
       .withDirectory("/tap", tap)
       .withDirectory("/upstream", upstreamRef.tree({ discardGitDir: true }))
       .withWorkdir("/upstream")
-      .withExec([
-        "node",
-        "-e",
-        [
-          "const fs = require('node:fs');",
-          "const path = 'apps/server/package.json';",
-          "const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));",
-          "pkg.version = process.argv[1];",
-          "fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\\n`);",
-        ].join(" "),
-        resolvedVersion,
-      ])
       .withExec(["bun", "install", "--frozen-lockfile"])
       .withExec(["bun", "run", "build", "--filter=@t3tools/web", "--filter=t3"])
       .withExec([

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -726,9 +726,23 @@ export class TapPipeline {
   }
 
   private async buildT3Artifact(tap: Directory, ref: string, version?: string): Promise<T3Build> {
-    const upstreamRef = dag.git("https://github.com/pingdotgg/t3code").ref(ref)
+    const entry = this.packageEntry("t3code-cli-main")
+
+    if (entry.upstream.kind !== "git" || entry.autoUpdate.kind !== "git_head_sha") {
+      throw new Error("Expected t3code-cli-main to use a git-head auto-update strategy")
+    }
+
+    const resolvedGitHead = version && version.length > 0
+      ? undefined
+      : await this.resolveGitHeadVersion(entry.upstream.repo, ref, entry.autoUpdate)
+    const upstreamRef = dag.git(entry.upstream.repo).ref(resolvedGitHead?.commit ?? ref)
     const commit = await upstreamRef.commit()
-    const resolvedVersion = version && version.length > 0 ? version : `smoke.${commit.slice(0, 12)}`
+    const resolvedVersion = version && version.length > 0 ? version : resolvedGitHead?.version
+
+    if (!resolvedVersion) {
+      throw new Error("Failed to resolve t3code-cli-main version")
+    }
+
     const assetName = `t3code-cli-main-${resolvedVersion}.tar.gz`
     const artifactPath = `/tmp/${assetName}`
 
@@ -736,18 +750,6 @@ export class TapPipeline {
       .withDirectory("/tap", tap)
       .withDirectory("/upstream", upstreamRef.tree({ discardGitDir: true }))
       .withWorkdir("/upstream")
-      .withExec([
-        "node",
-        "-e",
-        [
-          "const fs = require('node:fs');",
-          "const path = 'apps/server/package.json';",
-          "const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));",
-          "pkg.version = process.argv[1];",
-          "fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\\n`);",
-        ].join(" "),
-        resolvedVersion,
-      ])
       .withExec(["bun", "install", "--frozen-lockfile"])
       .withExec(["bun", "run", "build", "--filter=@t3tools/web", "--filter=t3"])
       .withExec([

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -43,8 +43,9 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     autoUpdate: {
       kind: "git_head_sha",
       ref: "main",
-      prefix: "smoke.",
+      prefix: "main.",
       shaLength: 12,
+      includeCommitDate: true,
     },
     upstream: {
       kind: "git",

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -157,6 +157,37 @@ test("fizzy-symphony opts into timestamped git-head versions", () => {
   }
 })
 
+test("t3code CLI main uses timestamped main snapshots instead of smoke labels", () => {
+  const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "t3code-cli-main")
+
+  assert.ok(entry)
+  assert.equal(entry.autoUpdate.kind, "git_head_sha")
+
+  if (entry.autoUpdate.kind === "git_head_sha") {
+    assert.equal(entry.autoUpdate.prefix, "main.")
+    assert.equal(entry.autoUpdate.includeCommitDate, true)
+  }
+})
+
+test("t3code CLI builders do not rewrite the upstream runtime package version", () => {
+  const builders = [
+    "../../../dagger/tap-pipeline/src/index.ts",
+    "../../../dagger/t3code-cli-main-smoke/src/index.ts",
+  ]
+
+  for (const builder of builders) {
+    const contents = readFileSync(new URL(builder, import.meta.url), "utf8")
+
+    assert.doesNotMatch(contents, /pkg\.version\s*=\s*process\.argv\[1\]/)
+  }
+})
+
+test("t3code CLI main formula bumps the Homebrew version scheme", () => {
+  const formula = readFileSync(new URL("../../../Formula/t3code-cli-main.rb", import.meta.url), "utf8")
+
+  assert.match(formula, /^\s*version_scheme 1$/m)
+})
+
 test("fizzy-symphony formula test stays credentialless", () => {
   const formula = readFileSync(new URL("../../../Formula/fizzy-symphony.rb", import.meta.url), "utf8")
 


### PR DESCRIPTION
## Root cause
Upstream T3 Code now compares the bundled web client version with the server runtime version. Our package build stamped only `apps/server/package.json` with the Homebrew snapshot label, so the client stayed `0.0.22` while the server reported `smoke.a74ed8ed32c2`.

## Changes
- Stop rewriting the upstream server runtime package version during T3 CLI packaging.
- Rename main-branch snapshot versions from `smoke.*` to timestamped `main.*`.
- Add `version_scheme 1` so Homebrew upgrades cleanly from the old smoke version.
- Add contract tests for the snapshot prefix, runtime-version behavior, and formula scheme.

## Validation
- `npm test --prefix dagger/tap-pipeline`
- `dagger -m ./dagger/tap-pipeline call list-packages`
- `dagger -m ./dagger/tap-pipeline call auto-update-status --slot-id=t3-daily`
- `dagger -m ./dagger/tap-pipeline call -o /tmp/t3-release-bundle release-bundle --package-id=t3code-cli-main`
- Artifact inspection: package metadata is `main.20260506230428.a74ed8ed32c2`; compiled client and server runtime versions are both `0.0.22`.