### PR TITLE
Update Codex Desktop Linux web-mode release

### DIFF
--- a/Casks/codex-desktop.rb
+++ b/Casks/codex-desktop.rb
@@ -1,8 +1,8 @@
 cask "codex-desktop" do
-  version "dmg.20260516022628.492a603ea9fa.conv.3f33b69cd2f7"
-  sha256 "0de56f22d1b50e09191a8870d03192ac5ab08ae9c2cab9cc69dd6e6389fea05f"
+  version "dmg.20260514200933.de0f41408b3a.conv.078c16d68e6f"
+  sha256 "52ad4d3493503b9b518d347644a02ca86587e08a158b9b00508c1502e1254546"
 
-  url "https://github.com/joshyorko/homebrew-tools/releases/download/codex-desktop-linux-dmg.20260516022628.492a603ea9fa.conv.3f33b69cd2f7/codex-desktop-linux-dmg.20260516022628.492a603ea9fa.conv.3f33b69cd2f7.tar.gz"
+  url "https://github.com/joshyorko/homebrew-tools/releases/download/codex-desktop-linux-dmg.20260514200933.de0f41408b3a.conv.078c16d68e6f/codex-desktop-linux-dmg.20260514200933.de0f41408b3a.conv.078c16d68e6f.tar.gz"
   name "Codex Desktop"
   desc "Linux runtime for a DMG-converted Codex Desktop app"
   homepage "https://github.com/joshyorko/homebrew-tools"

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ codex-desktop web --inspect
 ```
 
 The Dagger package id is `codex-desktop-linux`. The default conversion source is
-`joshyorko/codex-desktop-linux` at `5ff12de4dba995904edc6b2f37bf2b93628dc837`, and dispatch
+`joshyorko/codex-desktop-linux` at `078c16d68e6f1cb6ecdbff1f4054d70156ef42bb`, and dispatch
 builds use the validated conversion commit sent by that repo. The Codex Desktop repo checks the
 official DMG, validates the Linux conversion, and dispatches this tap to build the Homebrew artifact
 after that validation passes. The generated version includes both the DMG fingerprint and the

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -22,7 +22,7 @@ const GITHUB_AUTH_TOKEN = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN
 const CODEX_DESKTOP_CONVERSION_REPO =
   process.env.CODEX_DESKTOP_CONVERSION_REPO || "https://github.com/joshyorko/codex-desktop-linux"
 const CODEX_DESKTOP_CONVERSION_COMMIT =
-  process.env.CODEX_DESKTOP_CONVERSION_COMMIT || "5ff12de4dba995904edc6b2f37bf2b93628dc837"
+  process.env.CODEX_DESKTOP_CONVERSION_COMMIT || "078c16d68e6f1cb6ecdbff1f4054d70156ef42bb"
 const CODEX_DESKTOP_DMG_URL = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
 const CODEX_DESKTOP_MANUAL_VERSION = "research.20260514171029.43c8bd1b5d4a"
 const CODEX_DESKTOP_LINUX_FEATURES = ["remote-mobile-control", "open-target-discovery"]
@@ -1203,7 +1203,22 @@ export class TapPipeline {
         [
           "set -euo pipefail",
           "mkdir -p /work/fixture-app/resources/node-runtime/bin /work/fixture-app/resources/plugins/openai-bundled/plugins/computer-use/bin /work/fixture-app/resources/plugins/openai-bundled/plugins/chrome/extension-host/linux/x64 /work/fixture-app/resources/plugins/openai-bundled/plugins/chrome/scripts /work/fixture-app/.codex-linux /work/fixture-app/content/webview/assets /work/reports",
-          "printf '#!/usr/bin/env bash\\nset -euo pipefail\\necho \"fixture desktop launch:$*\"\\necho \"fixture codex path:$(command -v codex || true)\"\\necho \"fixture chrome user data:${CODEX_CHROME_USER_DATA_DIR:-}\"\\necho \"fixture editor:${EDITOR:-}\"\\n' > /work/fixture-app/start.sh",
+          "cat > /work/fixture-app/start.sh <<'SH'",
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          "if [ \"${1:-}\" = web ] && [ \"${2:-}\" = --inspect ]; then",
+          "  printf '%s\\n' '{\"package\":\"codex-desktop-linux\",\"mode\":\"devcontainer-web\",\"loopback_only_default\":true}'",
+          "  exit 0",
+          "fi",
+          "if [ \"${1:-}\" = web ]; then",
+          "  echo 'codex-desktop web is now served by: codex-desktop serve --workspace <path> --profile <path>' >&2",
+          "  exit 64",
+          "fi",
+          "echo \"fixture desktop launch:$*\"",
+          "echo \"fixture codex path:$(command -v codex || true)\"",
+          "echo \"fixture chrome user data:${CODEX_CHROME_USER_DATA_DIR:-}\"",
+          "echo \"fixture editor:${EDITOR:-}\"",
+          "SH",
           "chmod +x /work/fixture-app/start.sh",
           "printf '#!/usr/bin/env bash\\necho electron fixture\\n' > /work/fixture-app/electron",
           "chmod +x /work/fixture-app/electron",
@@ -2473,14 +2488,14 @@ export class TapPipeline {
               "test -f \"$HOME/.local/share/icons/hicolor/256x256/apps/codex-desktop.png\"",
               "codex-desktop logs --path",
               "web_report=$(codex-desktop web --inspect)",
-              "case \"$web_report\" in *'\"browser_mode_status\": \"research\"'*) ;; *) printf '%s\\n' \"$web_report\"; exit 1 ;; esac",
-              "case \"$web_report\" in *'\"serves_extracted_renderer\": false'*) ;; *) printf '%s\\n' \"$web_report\"; exit 1 ;; esac",
+              "case \"$web_report\" in *'\"mode\":\"devcontainer-web\"'*) ;; *) printf '%s\\n' \"$web_report\"; exit 1 ;; esac",
+              "case \"$web_report\" in *'\"loopback_only_default\":true'*) ;; *) printf '%s\\n' \"$web_report\"; exit 1 ;; esac",
               "set +e",
               "codex-desktop web >/tmp/codex-desktop-web.out 2>&1",
               "web_status=$?",
               "set -e",
               "test \"$web_status\" -eq 64",
-              "grep -q 'research-only' /tmp/codex-desktop-web.out",
+              "grep -q 'codex-desktop serve --workspace' /tmp/codex-desktop-web.out",
             ].join("\n"),
           ])
           .stdout()

--- a/dagger/tap-pipeline/tests/codex-desktop.test.ts
+++ b/dagger/tap-pipeline/tests/codex-desktop.test.ts
@@ -48,6 +48,14 @@ function createConvertedAppFixture(root: string): string {
     [
       "#!/usr/bin/env bash",
       "set -euo pipefail",
+      "if [ \"${1:-}\" = web ] && [ \"${2:-}\" = --inspect ]; then",
+      "  printf '%s\\n' '{\"package\":\"codex-desktop-linux\",\"mode\":\"devcontainer-web\",\"loopback_only_default\":true}'",
+      "  exit 0",
+      "fi",
+      "if [ \"${1:-}\" = web ]; then",
+      "  echo 'codex-desktop web is now served by: codex-desktop serve --workspace <path> --profile <path>' >&2",
+      "  exit 64",
+      "fi",
       "echo \"fixture desktop launch:$*\"",
       "echo \"fixture codex path:$(command -v codex || true)\"",
       "echo \"fixture chrome user data:${CODEX_CHROME_USER_DATA_DIR:-}\"",
@@ -296,12 +304,12 @@ test("codex desktop artifact packages a converted DMG app layout", () => {
     const webInspect = JSON.parse(
       execFileSync(join(extractDir, "bin/codex-desktop"), ["web", "--inspect"], { encoding: "utf8" }),
     )
-    assert.equal(webInspect.browser_mode_status, "research")
-    assert.equal(webInspect.serves_extracted_renderer, false)
+    assert.equal(webInspect.mode, "devcontainer-web")
+    assert.equal(webInspect.loopback_only_default, true)
 
     const webLaunch = spawnSync(join(extractDir, "bin/codex-desktop"), ["web"], { encoding: "utf8" })
     assert.equal(webLaunch.status, 64)
-    assert.match(webLaunch.stderr, /research-only/)
+    assert.match(webLaunch.stderr, /codex-desktop serve --workspace/)
 
     const dataHome = join(tmp, "xdg-data")
     const cacheHome = join(tmp, "xdg-cache")

--- a/dagger/tap-pipeline/tests/codex-desktop.test.ts
+++ b/dagger/tap-pipeline/tests/codex-desktop.test.ts
@@ -279,6 +279,19 @@ test("codex desktop artifact packages a converted DMG app layout", () => {
     const help = execFileSync(join(extractDir, "bin/codex-desktop"), ["--help"], { encoding: "utf8" })
     assert.match(help, /Usage: codex-desktop/)
     assert.match(help, /desktop/)
+    assert.match(help, /serve/)
+
+    const serveOsReleasePath = join(tmp, "serve-os-release")
+    writeFileSync(serveOsReleasePath, "NAME=Bluefin\nVARIANT_ID=bluefin\nID_LIKE=\"ublue fedora\"\n")
+    const serve = execFileSync(join(extractDir, "bin/codex-desktop"), ["serve", "--smoke"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODEX_DESKTOP_OS_RELEASE_FILE: serveOsReleasePath,
+      },
+    })
+    assert.match(serve, /fixture desktop launch:serve --smoke/)
+    assert.doesNotMatch(serve, /fixture desktop launch:--x11 serve --smoke/)
 
     const webInspect = JSON.parse(
       execFileSync(join(extractDir, "bin/codex-desktop"), ["web", "--inspect"], { encoding: "utf8" }),

--- a/scripts/package-codex-desktop-linux.mjs
+++ b/scripts/package-codex-desktop-linux.mjs
@@ -1274,6 +1274,7 @@ Usage: codex-desktop [command] [args]
 
 Commands:
   desktop                 Launch Codex Desktop
+  serve [args]            Run the Codex Desktop app launcher serve mode
   logs [--follow|--path]  Show the Codex Desktop launcher log
   doctor                  Check Bluefin/Linux runtime readiness
   --help, -h, help        Show this help
@@ -1642,6 +1643,16 @@ launch_desktop() {
   exec "$app_launcher" "\${args[@]}"
 }
 
+serve_mode() {
+  if [ ! -x "$app_launcher" ]; then
+    echo "Converted Codex Desktop launcher is missing or not executable: $app_launcher" >&2
+    exit 70
+  fi
+
+  unset ELECTRON_RUN_AS_NODE
+  exec "$app_launcher" serve "$@"
+}
+
 web_mode() {
   if [ "\${1:-}" = "--inspect" ]; then
     cat "$renderer_report"
@@ -1670,6 +1681,11 @@ case "\${1:-desktop}" in
     prepare_flatpak_browser_integration
     prepare_editor_integration
     launch_desktop "$@"
+    ;;
+  serve)
+    shift
+    prepare_runtime_path
+    serve_mode "$@"
     ;;
   logs)
     shift

--- a/scripts/package-codex-desktop-linux.mjs
+++ b/scripts/package-codex-desktop-linux.mjs
@@ -21,7 +21,7 @@ import { createRequire } from "node:module"
 const DEFAULT_CONVERSION_REPO =
   process.env.CODEX_DESKTOP_CONVERSION_REPO || "https://github.com/joshyorko/codex-desktop-linux"
 const DEFAULT_CONVERSION_COMMIT =
-  process.env.CODEX_DESKTOP_CONVERSION_COMMIT || "5ff12de4dba995904edc6b2f37bf2b93628dc837"
+  process.env.CODEX_DESKTOP_CONVERSION_COMMIT || "078c16d68e6f1cb6ecdbff1f4054d70156ef42bb"
 const LINUX_PROTOCOL_SCHEMES = ["codex", "codex-browser-sidebar"]
 const LINUX_RENDERER_COPY_REPLACEMENTS = [
   ["SSH connections from this Mac", "SSH connections from this computer"],

--- a/scripts/package-codex-desktop-linux.mjs
+++ b/scripts/package-codex-desktop-linux.mjs
@@ -1654,12 +1654,17 @@ serve_mode() {
 }
 
 web_mode() {
-  if [ "\${1:-}" = "--inspect" ]; then
-    cat "$renderer_report"
-    return 0
+  if [ ! -x "$app_launcher" ]; then
+    echo "Converted Codex Desktop launcher is missing or not executable: $app_launcher" >&2
+    exit 70
   fi
 
-  echo "Browser renderer mode is still research-only for this package. Run: codex-desktop web --inspect" >&2
+  if [ "\${1:-}" = "--inspect" ]; then
+    unset ELECTRON_RUN_AS_NODE
+    exec "$app_launcher" web --inspect
+  fi
+
+  echo "Browser renderer mode is served by: codex-desktop serve --workspace <path> --profile <path>" >&2
   exit 64
 }
 


### PR DESCRIPTION
Updates the codex-desktop cask and tap pipeline defaults to the merged codex-desktop-linux web-mode conversion commit.\n\nValidation:\n- npm test (dagger/tap-pipeline)\n- git diff --check\n- dagger -m ./dagger/tap-pipeline call -o /tmp/codex-bundle-webmode release-bundle --package-id=codex-desktop-linux\n\nRelease artifact:\n- https://github.com/joshyorko/homebrew-tools/releases/tag/codex-desktop-linux-dmg.20260514200933.de0f41408b3a.conv.078c16d68e6f