### PR TITLE
chore: update workflow dependency pins

### DIFF
--- a/.github/workflows/tap-auto-update.yml
+++ b/.github/workflows/tap-auto-update.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.21.3"
   GH_TOKEN: ${{ github.token }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   RELEASE_RETENTION_PER_PACKAGE: "3"

--- a/.github/workflows/tap-ci.yml
+++ b/.github/workflows/tap-ci.yml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.21.3"
   GH_TOKEN: ${{ github.token }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 

--- a/.github/workflows/tap-manual.yml
+++ b/.github/workflows/tap-manual.yml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.21.3"
   GH_TOKEN: ${{ github.token }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   RELEASE_RETENTION_PER_PACKAGE: "3"


### PR DESCRIPTION
## Automated RCC Maintenance

This PR updates allowed workflow dependency pins and refreshes the local RCC maintenance robot.

### Changed files


