### PR TITLE
[codex] Add Antigravity CLI formula and cache Codex release builds

### DIFF
--- a/Formula/antigravity-cli.rb
+++ b/Formula/antigravity-cli.rb
@@ -1,0 +1,42 @@
+class AntigravityCli < Formula
+  desc "Google Antigravity CLI"
+  homepage "https://antigravity.google/"
+  url "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-6458082025406464/linux-x64/cli_linux_x64.tar.gz"
+  version "1.0.6"
+  sha256 "3eae552781d3054b782142e3cfe7be73e3bd068c736a432ca6f1adaa40f19e07"
+  license :cannot_represent
+
+  livecheck do
+    skip "Google publishes this CLI through a platform manifest; update manually after verifying the checksum."
+  end
+
+  depends_on arch: :x86_64
+  depends_on :linux
+
+  def install
+    libexec.install "antigravity"
+
+    (bin/"agy").write <<~SH
+      #!/bin/bash
+      exec "#{libexec}/antigravity" "$@"
+    SH
+  end
+
+  def caveats
+    <<~EOS
+      This formula packages Google's closed-source Antigravity CLI binary for
+      Linux x86_64. It does not run the upstream installer during `brew install`.
+
+      First-run shell setup, if wanted:
+        agy install
+
+      Upstream installer reference:
+        curl -fsSL https://antigravity.google/cli/install.sh | bash
+    EOS
+  end
+
+  test do
+    output = shell_output("#{bin}/agy --version")
+    assert_match version.to_s, output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ An automation runtime for creating isolated, reproducible environments. Fork of 
 | `brew install --HEAD joshyorko/tools/codex-desktop-linux-builder` | Install Codex Desktop local builder tooling only |
 | `brew install joshyorko/tools/t3code-cli-main` | Install T3 Code CLI from `main` |
 | `brew install joshyorko/tools/codex-release` | Install Codex CLI from Josh Yorko's tap-release branch fork; executable remains `codex` |
+| `brew install joshyorko/tools/antigravity-cli` | Install Google Antigravity CLI for Linux x64; executable is `agy` |
 | `brew install joshyorko/tools/fizzy-cli-master` | Install Fizzy CLI from upstream `master` |
 | `brew install joshyorko/tools/fizzy-symphony` | Install Fizzy Symphony from `main` |
 | `brew install joshyorko/tools/eitype` | Install Eitype |
@@ -196,6 +197,23 @@ codex --help
 The formula token is `codex-release` so it does not collide with upstream, but it
 installs the `codex` executable and declares a conflict with any upstream `codex`
 formula that also owns that binary.
+
+### Antigravity CLI
+
+Google Antigravity CLI packaged from the upstream Linux x64 binary artifact.
+The upstream installer downloads a manifest, verifies SHA512, copies the binary
+as `agy`, and then runs first-run shell setup. This formula keeps the Homebrew
+install path explicit: it pins the verified tarball and installs only the `agy`
+launcher.
+
+> [!NOTE]
+> This is closed-source binary packaging, not a source build.
+> ```bash
+> brew install joshyorko/tools/antigravity-cli
+> agy --help
+> ```
+
+Run `agy install` after installation if you want Antigravity's own shell setup.
 
 ### Codex Desktop (Linux DMG Conversion Runtime)
 

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -1233,6 +1233,11 @@ end
     const container = this.rustBaseContainer()
       .withDirectory("/tap", tap)
       .withDirectory("/upstream", upstreamRef.tree({ discardGitDir: true }))
+      .withMountedCache(
+        "/upstream/codex-rs/target",
+        dag.cacheVolume("tap-pipeline-cargo-target-codex-release"),
+        { sharing: CacheSharingMode.Locked },
+      )
       .withWorkdir("/upstream/codex-rs")
       .withExec(["cargo", "build", "--locked", "--release", "--bin", "codex"])
       .withExec([

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -133,6 +133,11 @@ function tapStagingCommands(packageId: string): string[] {
         "mkdir -p \"$tap_dir/Formula\"",
         "cp /tap/Formula/codex-release.rb \"$tap_dir/Formula/\"",
       ]
+    case "antigravity-cli":
+      return [
+        "mkdir -p \"$tap_dir/Formula\"",
+        "cp /tap/Formula/antigravity-cli.rb \"$tap_dir/Formula/\"",
+      ]
     case "fizzy-cli-master":
       return [
         "mkdir -p \"$tap_dir/Formula\"",
@@ -1995,6 +2000,8 @@ end
           codexDesktopConversionCommit,
         )).version
       }
+      case "manual":
+        throw new Error(`${packageId} is manually updated: ${entry.autoUpdate.reason}`)
     }
   }
 
@@ -2524,6 +2531,30 @@ end
           await build.container.withExec(["sha256sum", build.artifactPath]).stdout()
         ).trim().split(/\s+/)[0]
         return this.codexReleaseSmokeLog(tap, build, sha256)
+      }
+      case "antigravity-cli": {
+        return dag
+          .container()
+          .from(BREW_IMAGE)
+          .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
+          .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
+          .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
+          .withDirectory("/tap", tap)
+          .withExec([
+            "bash",
+            "-lc",
+            [
+              "set -euo pipefail",
+              "repo=$(brew --repository)",
+              "tap_dir=\"$repo/Library/Taps/test/homebrew-tap\"",
+              ...tapStagingCommands("antigravity-cli"),
+              "brew install test/tap/antigravity-cli",
+              "brew test test/tap/antigravity-cli",
+              "agy --version",
+              "agy --help",
+            ].join("\n"),
+          ])
+          .stdout()
       }
       case "fizzy-cli-master": {
         const build = await this.buildFizzyArtifact(tap, "master")

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -72,6 +72,20 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     },
   },
   {
+    id: "antigravity-cli",
+    kind: "http_binary_formula",
+    homebrewPath: "Formula/antigravity-cli.rb",
+    supportsPrCi: true,
+    autoUpdate: {
+      kind: "manual",
+      reason: "Google publishes Antigravity CLI through a platform manifest; update after verifying checksums.",
+    },
+    upstream: {
+      kind: "http_file",
+      url: "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-6458082025406464/linux-x64/cli_linux_x64.tar.gz",
+    },
+  },
+  {
     id: "fizzy-cli-master",
     kind: "source_build_go_formula",
     homebrewPath: "Formula/fizzy-cli-master.rb",
@@ -246,6 +260,7 @@ const CHANGED_PATHS: Array<[string, string[]]> = [
     "codex-release",
     ["Formula/codex-release.rb", "scripts/package-codex-release.mjs"],
   ],
+  ["antigravity-cli", ["Formula/antigravity-cli.rb"]],
   [
     "fizzy-cli-master",
     ["Formula/fizzy-cli-master.rb", "scripts/package-fizzy-cli-master.mjs", "dagger/fizzy-cli-master-smoke/"],

--- a/dagger/tap-pipeline/src/types.ts
+++ b/dagger/tap-pipeline/src/types.ts
@@ -3,6 +3,7 @@ export type PackageKind =
   | "rpm_repack_cask"
   | "source_build_rust_formula"
   | "source_build_go_formula"
+  | "http_binary_formula"
   | "github_release_binary_cask"
   | "github_release_deb_cask"
   | "github_release_appimage_cask"
@@ -60,6 +61,10 @@ export type AutoUpdateStrategy =
       kind: "http_header_fingerprint"
       prefix?: string
       shaLength?: number
+    }
+  | {
+      kind: "manual"
+      reason: string
     }
 
 export type PackageRegistryEntry = {

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -28,6 +28,7 @@ test("package registry covers every planned adapter kind", () => {
       "github_release_appimage_cask",
       "github_release_binary_cask",
       "github_release_deb_cask",
+      "http_binary_formula",
       "rpm_repack_cask",
       "source_build_go_formula",
       "source_build_node_formula",
@@ -187,6 +188,23 @@ test("codex release tracks the fork tap-release branch and installs codex", () =
   assert.match(formula, /conflicts_with "codex"/)
   assert.match(formula, /bin\/"codex"/)
   assert.match(formula, /tap-release branch/)
+})
+
+test("antigravity CLI is a manual closed-source binary formula", () => {
+  const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "antigravity-cli")
+
+  assert.ok(entry)
+  assert.equal(entry.kind, "http_binary_formula")
+  assert.equal(entry.homebrewPath, "Formula/antigravity-cli.rb")
+  assert.equal(entry.supportsPrCi, true)
+  assert.equal(entry.autoUpdate.kind, "manual")
+  assert.equal(entry.upstream.kind, "http_file")
+
+  const formula = readFileSync(new URL("../../../Formula/antigravity-cli.rb", import.meta.url), "utf8")
+
+  assert.match(formula, /class AntigravityCli < Formula/)
+  assert.match(formula, /bin\/"agy"/)
+  assert.match(formula, /license :cannot_represent/)
 })
 
 test("codex desktop is not registered for tap auto-update or release publishing", () => {

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -190,6 +190,22 @@ test("codex release tracks the fork tap-release branch and installs codex", () =
   assert.match(formula, /tap-release branch/)
 })
 
+test("codex release build keeps a Dagger cargo target cache", () => {
+  const source = readFileSync(new URL("../../../dagger/tap-pipeline/src/index.ts", import.meta.url), "utf8")
+  const sectionMatch = source.match(/private async buildCodexReleaseArtifact[\s\S]*?private async codexReleaseSmokeLog/)
+
+  assert.ok(sectionMatch)
+
+  const section = sectionMatch[0]
+  const cacheIndex = section.indexOf('dag.cacheVolume("tap-pipeline-cargo-target-codex-release")')
+  const buildIndex = section.indexOf('.withExec(["cargo", "build", "--locked", "--release", "--bin", "codex"])')
+
+  assert.match(section, /"\/upstream\/codex-rs\/target"/)
+  assert.notEqual(cacheIndex, -1)
+  assert.notEqual(buildIndex, -1)
+  assert.equal(cacheIndex < buildIndex, true)
+})
+
 test("antigravity CLI is a manual closed-source binary formula", () => {
   const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "antigravity-cli")
 

--- a/dagger/tap-pipeline/tests/planner.test.ts
+++ b/dagger/tap-pipeline/tests/planner.test.ts
@@ -35,18 +35,20 @@ test("packagesForAutoUpdateSlot rejects unknown slots", () => {
 test("changedCiPackagesFromPaths only returns PR-enabled packages", () => {
   const changed = changedCiPackagesFromPaths([
     "Casks/rcc.rb",
+    "Formula/antigravity-cli.rb",
     "Formula/voxtype.rb",
     "Formula/eitype.rb",
     "README.md",
   ])
 
-  assert.deepEqual([...changed].sort(), ["eitype", "rcc", "voxtype"])
+  assert.deepEqual([...changed].sort(), ["antigravity-cli", "eitype", "rcc", "voxtype"])
 })
 
 test("every PR-enabled package has a changed-path trigger", () => {
   const fixtures: Record<string, string> = {
     "t3code-cli-main": "Formula/t3code-cli-main.rb",
     "codex-release": "Formula/codex-release.rb",
+    "antigravity-cli": "Formula/antigravity-cli.rb",
     "fizzy-cli-master": "Formula/fizzy-cli-master.rb",
     "fizzy-popper-self-hosted": "Formula/fizzy-popper-self-hosted.rb",
     "fizzy-symphony": "Formula/fizzy-symphony.rb",


### PR DESCRIPTION
## Summary

Adds Google Antigravity CLI as a Linux x64 Homebrew formula in this tap. The formula pins the upstream closed-source binary artifact, installs the `agy` launcher, and leaves upstream first-run shell setup as an explicit `agy install` step.

This also registers `antigravity-cli` in the tap-pipeline package registry as a manual HTTP binary formula with PR CI support. It is intentionally not added to scheduled auto-update slots; a manifest-based updater can be added separately later.

Adds a Dagger cache volume for the Codex release Cargo target directory at `/upstream/codex-rs/target`, so repeated `codex-release` bundle exports can reuse Rust build artifacts instead of cold-building the whole release binary every time.

## Validation

- `npm test --prefix dagger/tap-pipeline`
- `brew style Formula/antigravity-cli.rb`
- `git diff --check`
- `ruby -c Formula/antigravity-cli.rb`
- `dagger -m ./dagger/tap-pipeline call ci-check --package-id=antigravity-cli`
- `dagger -m ./dagger/tap-pipeline call detect-changed-packages --base-ref=origin/main --head-ref=HEAD` returned `["antigravity-cli"]`