### PR TITLE
[codex] Consume Codex Linux tap release asset

### DIFF
--- a/Formula/codex-release.rb
+++ b/Formula/codex-release.rb
@@ -16,11 +16,11 @@ class CodexRelease < Formula
   conflicts_with "codex", because: "both install a codex executable"
 
   def install
-    libexec.install "codex"
+    libexec.install Dir["*"]
 
     (bin/"codex").write <<~SH
       #!/bin/bash
-      exec "#{libexec}/codex" "$@"
+      exec "#{libexec}/bin/codex" "$@"
     SH
   end
 

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -1210,6 +1210,7 @@ end
     ref: string,
     version?: string,
   ): Promise<CodexReleaseBuild> {
+    void tap
     const entry = this.packageEntry("codex-release")
 
     if (entry.upstream.kind !== "git" || entry.autoUpdate.kind !== "git_head_sha") {
@@ -1219,8 +1220,7 @@ end
     const resolvedGitHead = version && version.length > 0
       ? undefined
       : await this.resolveGitHeadVersion(entry.upstream.repo, ref, entry.autoUpdate)
-    const upstreamRef = dag.git(entry.upstream.repo).ref(resolvedGitHead?.commit ?? ref)
-    const commit = await upstreamRef.commit()
+    const commit = resolvedGitHead?.commit ?? await dag.git(entry.upstream.repo).ref(ref).commit()
     const resolvedVersion = version && version.length > 0 ? version : resolvedGitHead?.version
 
     if (!resolvedVersion) {
@@ -1229,29 +1229,21 @@ end
 
     const assetName = `codex-release-${resolvedVersion}.tar.gz`
     const artifactPath = `/tmp/${assetName}`
+    const releaseTag = `codex-release-${resolvedVersion}`
+    const release = await this.fetchJson(
+      `${githubApiRepoUrl(entry.upstream.repo)}/releases/tags/${encodeURIComponent(releaseTag)}`,
+    ) as {
+      assets: Array<{ name: string; browser_download_url: string }>
+    }
+    const asset = release.assets.find((candidate) => candidate.name === assetName)
 
-    const container = this.rustBaseContainer()
-      .withDirectory("/tap", tap)
-      .withDirectory("/upstream", upstreamRef.tree({ discardGitDir: true }))
-      .withMountedCache(
-        "/upstream/codex-rs/target",
-        dag.cacheVolume("tap-pipeline-cargo-target-codex-release"),
-        { sharing: CacheSharingMode.Locked },
-      )
-      .withWorkdir("/upstream/codex-rs")
-      .withExec(["cargo", "build", "--locked", "--release", "--bin", "codex"])
-      .withExec([
-        "node",
-        "/tap/scripts/package-codex-release.mjs",
-        "--upstream-dir",
-        "/upstream",
-        "--binary",
-        "/upstream/codex-rs/target/release/codex",
-        "--version",
-        resolvedVersion,
-        "--output",
-        artifactPath,
-      ])
+    if (!asset) {
+      const names = release.assets.map((candidate) => candidate.name).sort().join(", ") || "none"
+      throw new Error(`Missing Codex Linux release asset ${assetName} on ${releaseTag}; found: ${names}`)
+    }
+
+    let container = this.githubApiContainer()
+    container = this.downloadAsset(container, asset.browser_download_url, artifactPath)
 
     return {
       artifactPath,

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -186,24 +186,24 @@ test("codex release tracks the fork tap-release branch and installs codex", () =
   const formula = readFileSync(new URL("../../../Formula/codex-release.rb", import.meta.url), "utf8")
 
   assert.match(formula, /conflicts_with "codex"/)
-  assert.match(formula, /bin\/"codex"/)
+  assert.match(formula, /libexec\.install Dir\["\*"\]/)
+  assert.match(formula, /exec "#\{libexec\}\/bin\/codex" "\$@"/)
   assert.match(formula, /tap-release branch/)
 })
 
-test("codex release build keeps a Dagger cargo target cache", () => {
+test("codex release bundle consumes the fork's Linux release asset instead of compiling", () => {
   const source = readFileSync(new URL("../../../dagger/tap-pipeline/src/index.ts", import.meta.url), "utf8")
   const sectionMatch = source.match(/private async buildCodexReleaseArtifact[\s\S]*?private async codexReleaseSmokeLog/)
 
   assert.ok(sectionMatch)
 
   const section = sectionMatch[0]
-  const cacheIndex = section.indexOf('dag.cacheVolume("tap-pipeline-cargo-target-codex-release")')
-  const buildIndex = section.indexOf('.withExec(["cargo", "build", "--locked", "--release", "--bin", "codex"])')
 
-  assert.match(section, /"\/upstream\/codex-rs\/target"/)
-  assert.notEqual(cacheIndex, -1)
-  assert.notEqual(buildIndex, -1)
-  assert.equal(cacheIndex < buildIndex, true)
+  assert.match(section, /githubApiContainer/)
+  assert.match(section, /downloadAsset/)
+  assert.match(section, /githubApiRepoUrl\(entry\.upstream\.repo\)/)
+  assert.doesNotMatch(section, /cargo", "build"/)
+  assert.doesNotMatch(section, /tap-pipeline-cargo-target-codex-release/)
 })
 
 test("antigravity CLI is a manual closed-source binary formula", () => {


### PR DESCRIPTION
## Summary
- consume the matching `joshyorko/codex` Linux tap release asset instead of building Codex inside the tap pipeline
- preserve the canonical Codex package layout in the formula by installing the package under `libexec` and wrapping `bin/codex`
- fail fast when the expected `codex-release-<version>.tar.gz` asset is missing

## Validation
- `npm test --prefix dagger/tap-pipeline`
- `brew style Formula/codex-release.rb`
- `ruby -c Formula/codex-release.rb`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tap-auto-update.yml"); puts "tap auto-update yaml ok"'`\n- `git diff --check`\n\n## Note\n`actionlint .github/workflows/tap-auto-update.yml .github/workflows/tap-ci.yml .github/workflows/tap-manual.yml` still reports the pre-existing SC2129 shell style warning in `tap-auto-update.yml`; this branch does not change that workflow script.