### PR TITLE
Add local Codex release install path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .rcc_home/
 .tools/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,25 @@
 CODEX_DESKTOP_CONVERSION_REF_FILE ?= codex-desktop-conversion.ref
 CODEX_DESKTOP_CONVERSION_COMMIT ?= $(shell ref="$$(sed -e 's/[[:space:]]*\#.*//' -e '/^[[:space:]]*$$/d' "$(CODEX_DESKTOP_CONVERSION_REF_FILE)" 2>/dev/null | head -n 1)"; printf '%s\n' "$${ref:-self-hosted}")
 CODEX_DESKTOP_INSTALL_ARGS = --conversion-commit "$(CODEX_DESKTOP_CONVERSION_COMMIT)"
+CODEX_RELEASE_INSTALL_ARGS =
+
+ifneq ($(strip $(CODEX_REPO)),)
+CODEX_RELEASE_INSTALL_ARGS += --codex-repo "$(CODEX_REPO)"
+endif
+
+ifneq ($(strip $(CODEX_RELEASE_ARTIFACT)),)
+CODEX_RELEASE_INSTALL_ARGS += --artifact "$(CODEX_RELEASE_ARTIFACT)"
+endif
+
+ifneq ($(strip $(CODEX_RELEASE_BUNDLE_DIR)),)
+CODEX_RELEASE_INSTALL_ARGS += --bundle-dir "$(CODEX_RELEASE_BUNDLE_DIR)"
+endif
+
+ifneq ($(strip $(CODEX_RELEASE_SKIP_INSTALL)),)
+CODEX_RELEASE_INSTALL_ARGS += --skip-install
+endif
+
+CODEX_RELEASE_INSTALL_ARGS += $(CODEX_RELEASE_INSTALL_EXTRA_ARGS)
 
 ifneq ($(strip $(CODEX_DESKTOP_CODEX_DMG)),)
 CODEX_DESKTOP_INSTALL_ARGS += --codex-dmg "$(CODEX_DESKTOP_CODEX_DMG)"
@@ -16,7 +35,12 @@ endif
 
 CODEX_DESKTOP_INSTALL_ARGS += $(CODEX_DESKTOP_INSTALL_EXTRA_ARGS)
 
-.PHONY: codex-desktop-install codex-install codex-desktop-uninstall codex-desktop-zap codex-desktop-rebuild-relaunch codex-desktop-rebuild-foreground codex-desktop-rebuild-dry-run test-codex-desktop-rebuild install-codex-desktop uninstall-codex-desktop zap-codex-desktop
+.PHONY: codex codex-release-local codex-desktop-install codex-install codex-desktop-uninstall codex-desktop-zap codex-desktop-rebuild-relaunch codex-desktop-rebuild-foreground codex-desktop-rebuild-dry-run test-codex-desktop-rebuild install-codex-desktop uninstall-codex-desktop zap-codex-desktop
+
+codex:
+	scripts/install-codex-release-local.sh $(CODEX_RELEASE_INSTALL_ARGS) -- $(CODEX_RELEASE_BUILD_ARGS)
+
+codex-release-local: codex
 
 codex-desktop-install:
 	scripts/install-codex-desktop-local.sh $(CODEX_DESKTOP_INSTALL_ARGS)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,30 @@ The formula token is `codex-release` so it does not collide with upstream, but i
 installs the `codex` executable and declares a conflict with any upstream `codex`
 formula that also owns that binary.
 
+For fast local iteration from a repo checkout, build the Codex asset locally and
+install it through a temporary local tap:
+
+```bash
+CODEX_REPO=/path/to/joshyorko/codex make codex
+```
+
+`make codex` calls the Codex checkout's `just local-tap-release`, reuses that
+checkout's `.codex-local-build/` dependency and target caches, passes the
+resulting `dist/local-tap-release/codex-release-*.tar.gz` to the local Dagger
+tap pipeline, writes the rendered bundle under `dist/codex-release-local/`, and
+runs `brew install` or `brew reinstall` from a temporary tap. Use
+`CODEX_RELEASE_SKIP_INSTALL=1 make codex` to only build and render the local
+bundle.
+
+To install from an already-built local tarball:
+
+```bash
+CODEX_RELEASE_ARTIFACT=/path/to/codex-release-release.20260608000000.abc123.tar.gz make codex
+```
+
+Extra Codex build flags pass through with `CODEX_RELEASE_BUILD_ARGS`, for
+example `CODEX_RELEASE_BUILD_ARGS=--rebuild-image make codex`.
+
 ### Antigravity CLI
 
 Google Antigravity CLI packaged from the upstream Linux x64 binary artifact.

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -862,6 +862,64 @@ export class TapPipeline {
     })
   }
 
+  private codexReleaseLocalMetadata(build: CodexReleaseBuild, sha256: string): Record<string, unknown> {
+    return releaseMetadataForPackage("codex-release", {
+      version: build.version,
+      releaseTag: `codex-release-${build.version}`,
+      assetName: build.assetName,
+      artifactSha256: sha256,
+      downloadUrl: "file://${CODEX_RELEASE_LOCAL_ARTIFACT}",
+      releaseTitle: `Local Codex release ${build.version}`,
+      releaseNotes: `Local-only Homebrew install bundle built from joshyorko/codex@${build.commit} on this machine.`,
+      commitMessage: `Build local codex-release formula for ${build.version}`,
+      upstream: {
+        kind: "git",
+        repo: "https://github.com/joshyorko/codex",
+        ref: "tap-release",
+        version: build.version,
+        commit: build.commit,
+      },
+    })
+  }
+
+  private async buildLocalCodexReleaseArtifact(
+    codexReleaseArtifact: File,
+    codexCommit?: string,
+  ): Promise<CodexReleaseBuild> {
+    const assetName = await codexReleaseArtifact.name()
+    const prefix = "codex-release-"
+    const suffix = ".tar.gz"
+
+    if (!assetName.startsWith(prefix) || !assetName.endsWith(suffix)) {
+      throw new Error(`Expected artifact name like codex-release-<version>.tar.gz, got: ${assetName}`)
+    }
+
+    const version = assetName.slice(prefix.length, -suffix.length)
+    const parsedCommit = version.split(".").at(-1) ?? "unknown"
+    const artifactPath = `/inputs/${assetName}`
+    const container = dag
+      .container()
+      .from(NODE_IMAGE)
+      .withFile(artifactPath, codexReleaseArtifact)
+
+    return {
+      artifactPath,
+      assetName,
+      commit: codexCommit && codexCommit.length > 0 ? codexCommit : parsedCommit,
+      container,
+      version,
+    }
+  }
+
+  private async renderCodexReleaseLocalFormula(version: string, sha256: string): Promise<string> {
+    const formulaContents = await this.source.file("Formula/codex-release.rb").contents()
+
+    return formulaContents
+      .replace(/url ".*"/, 'url "file://#{ENV.fetch("CODEX_RELEASE_LOCAL_ARTIFACT")}"')
+      .replace(/version ".*"/, `version "${version}"`)
+      .replace(/sha256 ".*"/, `sha256 "${sha256}"`)
+  }
+
   private fizzyReleaseMetadata(build: FizzyBuild, sha256: string): Record<string, unknown> {
     return releaseMetadataForPackage("fizzy-cli-master", {
       version: build.version,
@@ -3380,5 +3438,34 @@ end
       .withFile("homebrew/codex-desktop.rb", dag.file("codex-desktop.rb", caskContents))
       .withFile("release.json", dag.file("release.json", json(localMetadata)))
       .withFile("renderer-report.json", dag.file("renderer-report.json", await this.codexDesktopRendererReport(codexDmgFile)))
+  }
+
+  @func()
+  async codexReleaseLocalBundle(
+    codexReleaseArtifact: File,
+    codexCommit?: string,
+  ): Promise<Directory> {
+    const build = await this.buildLocalCodexReleaseArtifact(codexReleaseArtifact, codexCommit)
+    const sha256 = (
+      await build.container.withExec(["sha256sum", build.artifactPath]).stdout()
+    ).trim().split(/\s+/)[0]
+    const formulaContents = await this.renderCodexReleaseLocalFormula(build.version, sha256)
+    const localMetadata: Record<string, unknown> = {
+      ...this.codexReleaseLocalMetadata(build, sha256),
+      distribution: "local-only",
+    }
+    const ciLog = [
+      "Local Codex release bundle.",
+      `artifact=artifacts/${build.assetName}`,
+      `formula=homebrew/codex-release.rb`,
+      `sha256=${sha256}`,
+      "",
+    ].join("\n")
+
+    return dag.directory()
+      .withFile(`artifacts/${build.assetName}`, build.container.file(build.artifactPath))
+      .withFile("homebrew/codex-release.rb", dag.file("codex-release.rb", formulaContents))
+      .withFile("release.json", dag.file("release.json", json(localMetadata)))
+      .withFile("ci.log", dag.file("ci.log", ciLog))
   }
 }

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -206,6 +206,25 @@ test("codex release bundle consumes the fork's Linux release asset instead of co
   assert.doesNotMatch(section, /tap-pipeline-cargo-target-codex-release/)
 })
 
+test("codex release local bundle accepts a locally built artifact", () => {
+  const source = readFileSync(new URL("../../../dagger/tap-pipeline/src/index.ts", import.meta.url), "utf8")
+  const installer = readFileSync(new URL("../../../scripts/install-codex-release-local.sh", import.meta.url), "utf8")
+  const makefile = readFileSync(new URL("../../../Makefile", import.meta.url), "utf8")
+  const readme = readFileSync(new URL("../../../README.md", import.meta.url), "utf8")
+
+  assert.match(source, /codexReleaseLocalBundle/)
+  assert.match(source, /codexReleaseArtifact: File/)
+  assert.match(source, /buildLocalCodexReleaseArtifact/)
+  assert.match(source, /CODEX_RELEASE_LOCAL_ARTIFACT/)
+  assert.match(installer, /codex-release-local-bundle/)
+  assert.match(installer, /--codex-release-artifact=\$artifact/)
+  assert.match(installer, /CODEX_RELEASE_LOCAL_ARTIFACT="\$artifact"/)
+  assert.match(makefile, /^codex:/m)
+  assert.match(makefile, /CODEX_RELEASE_BUILD_ARGS/)
+  assert.match(readme, /CODEX_REPO=\/path\/to\/joshyorko\/codex make codex/)
+  assert.match(readme, /CODEX_RELEASE_ARTIFACT=\/path\/to\/codex-release-release/)
+})
+
 test("antigravity CLI is a manual closed-source binary formula", () => {
   const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "antigravity-cli")
 

--- a/scripts/install-codex-release-local.sh
+++ b/scripts/install-codex-release-local.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/install-codex-release-local.sh [options] [-- <codex build args>]
+
+Build a local Codex release asset from a joshyorko/codex checkout, render a
+local Homebrew formula for that artifact, and optionally install it through a
+temporary tap.
+
+Options:
+  --codex-repo PATH       Path to a joshyorko/codex checkout with just local-tap-release.
+  --artifact PATH         Use an already-built codex-release-*.tar.gz instead of building.
+  --bundle-dir PATH       Write the local bundle here instead of a temp dir.
+  --skip-install          Build/render only; do not run brew install/reinstall.
+  -h, --help              Show this help.
+
+Environment defaults:
+  CODEX_REPO                 Codex checkout used when --codex-repo is omitted.
+  CODEX_RELEASE_ARTIFACT     Prebuilt tarball used when --artifact is omitted.
+  CODEX_RELEASE_BUNDLE_DIR   Bundle directory used when --bundle-dir is omitted.
+  CODEX_RELEASE_SKIP_INSTALL Set to any non-empty value to imply --skip-install.
+  CODEX_RELEASE_BUILD_ARGS   Extra args passed by the Makefile after --.
+EOF
+}
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+codex_repo="${CODEX_REPO:-}"
+artifact="${CODEX_RELEASE_ARTIFACT:-}"
+bundle_dir="${CODEX_RELEASE_BUNDLE_DIR:-$repo_dir/dist/codex-release-local}"
+skip_install=0
+temp_tap_name=""
+install_succeeded=0
+codex_build_args=()
+
+if [ -n "${CODEX_RELEASE_SKIP_INSTALL:-}" ]; then
+    skip_install=1
+fi
+
+cleanup() {
+    status=$?
+    trap - EXIT
+
+    if [ -n "$temp_tap_name" ]; then
+        brew untap --force "$temp_tap_name" >/dev/null 2>&1 || true
+    fi
+
+    return "$status"
+}
+
+trap cleanup EXIT
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --codex-repo)
+            codex_repo="${2:-}"
+            [ -n "$codex_repo" ] || { echo "--codex-repo requires a path" >&2; exit 64; }
+            shift 2
+            ;;
+        --artifact)
+            artifact="${2:-}"
+            [ -n "$artifact" ] || { echo "--artifact requires a path" >&2; exit 64; }
+            shift 2
+            ;;
+        --bundle-dir)
+            bundle_dir="${2:-}"
+            [ -n "$bundle_dir" ] || { echo "--bundle-dir requires a path" >&2; exit 64; }
+            shift 2
+            ;;
+        --skip-install)
+            skip_install=1
+            shift
+            ;;
+        --)
+            shift
+            codex_build_args=("$@")
+            break
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 64
+            ;;
+    esac
+done
+
+resolve_codex_repo() {
+    local candidate
+    local candidates=()
+
+    if [ -n "$codex_repo" ]; then
+        candidates+=("$codex_repo")
+    fi
+
+    candidates+=(
+        "$repo_dir/../codex"
+        "$HOME/second_brain/Areas/devcontainers/codex"
+        "$HOME/.config/superpowers/worktrees/codex/patchraptor-linux-only-codex-tap-release"
+    )
+
+    for candidate in "${candidates[@]}"; do
+        [ -n "$candidate" ] || continue
+        if [ -x "$candidate/scripts/build-local-tap-release.sh" ] && [ -f "$candidate/justfile" ]; then
+            realpath "$candidate"
+            return 0
+        fi
+    done
+
+    cat >&2 <<'EOF'
+Could not find a Codex checkout with scripts/build-local-tap-release.sh.
+Set CODEX_REPO=/path/to/joshyorko/codex or pass --codex-repo.
+EOF
+    exit 66
+}
+
+if ! command -v dagger >/dev/null 2>&1; then
+    echo "dagger is required. Install it first, then rerun this script." >&2
+    exit 69
+fi
+
+export DAGGER_NO_NAG="${DAGGER_NO_NAG:-1}"
+
+if [ -z "$artifact" ]; then
+    codex_repo="$(resolve_codex_repo)"
+    if ! command -v just >/dev/null 2>&1; then
+        echo "just is required to call the Codex local tap release builder." >&2
+        exit 69
+    fi
+else
+    artifact="$(realpath "$artifact")"
+    [ -f "$artifact" ] || { echo "Codex release artifact not found: $artifact" >&2; exit 66; }
+fi
+
+mkdir -p "$bundle_dir"
+bundle_dir="$(realpath "$bundle_dir")"
+
+if [ -z "$artifact" ]; then
+    commit="$(git -C "$codex_repo" rev-parse HEAD)"
+    committed_at="$(git -C "$codex_repo" show -s --format=%cI HEAD)"
+    timestamp="$(date -u -d "$committed_at" +%Y%m%d%H%M%S)"
+    version="release.${timestamp}.${commit:0:12}"
+    asset_name="codex-release-${version}.tar.gz"
+    expected_artifact="$codex_repo/dist/local-tap-release/$asset_name"
+
+    echo "Building local Codex release asset from $codex_repo"
+    echo "Expected version: $version"
+    (cd "$codex_repo" && just local-tap-release "${codex_build_args[@]}")
+
+    if [ ! -f "$expected_artifact" ]; then
+        echo "Codex local builder did not produce expected artifact: $expected_artifact" >&2
+        exit 70
+    fi
+    artifact="$expected_artifact"
+else
+    asset_name="$(basename "$artifact")"
+    if [[ "$asset_name" != codex-release-*.tar.gz ]]; then
+        echo "Expected artifact name like codex-release-<version>.tar.gz, got: $asset_name" >&2
+        exit 65
+    fi
+    version="${asset_name#codex-release-}"
+    version="${version%.tar.gz}"
+    commit="${version##*.}"
+fi
+
+artifact="$(realpath "$artifact")"
+asset_name="$(basename "$artifact")"
+version="${asset_name#codex-release-}"
+version="${version%.tar.gz}"
+release_tag="codex-release-${version}"
+
+case "$artifact" in
+    "$bundle_dir"/*) ;;
+    *)
+        rm -rf "$bundle_dir"
+        mkdir -p "$bundle_dir"
+        ;;
+esac
+
+dagger_args=(
+    --silent
+    -m "$repo_dir/dagger/tap-pipeline"
+    call
+    -o "$bundle_dir"
+    codex-release-local-bundle
+    "--codex-release-artifact=$artifact"
+)
+
+if [ -n "${commit:-}" ]; then
+    dagger_args+=("--codex-commit=$commit")
+fi
+
+echo "Rendering local Codex release bundle into $bundle_dir"
+(cd "$repo_dir" && dagger "${dagger_args[@]}")
+
+artifact="$bundle_dir/artifacts/$asset_name"
+formula_file="$bundle_dir/homebrew/codex-release.rb"
+release_file="$bundle_dir/release.json"
+
+if [ ! -f "$artifact" ]; then
+    echo "Local Codex release artifact was not produced at $artifact" >&2
+    exit 70
+fi
+if [ ! -f "$formula_file" ]; then
+    echo "Local Codex release formula was not produced at $formula_file" >&2
+    exit 70
+fi
+if [ ! -f "$release_file" ]; then
+    echo "Local Codex release metadata was not produced at $release_file" >&2
+    exit 70
+fi
+
+echo "Local artifact: $bundle_dir/artifacts/$asset_name"
+echo "Local formula: $formula_file"
+echo "Local bundle: $bundle_dir"
+
+if [ "$skip_install" -eq 1 ]; then
+    echo "Build complete. Skipping Homebrew install."
+    exit 0
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "brew is required unless --skip-install is set." >&2
+    exit 69
+fi
+
+export HOMEBREW_NO_AUTO_UPDATE="${HOMEBREW_NO_AUTO_UPDATE:-1}"
+export HOMEBREW_NO_ENV_HINTS="${HOMEBREW_NO_ENV_HINTS:-1}"
+export HOMEBREW_NO_INSTALL_FROM_API="${HOMEBREW_NO_INSTALL_FROM_API:-1}"
+export CODEX_RELEASE_LOCAL_ARTIFACT="$artifact"
+
+temp_tap_name="codex-local/codex-release-local-$(date +%s)-$$"
+brew tap-new --no-git "$temp_tap_name" >/dev/null
+temp_tap_dir="$(brew --repository "$temp_tap_name")"
+mkdir -p "$temp_tap_dir/Formula"
+cp "$formula_file" "$temp_tap_dir/Formula/codex-release.rb"
+brew ruby -- -e '
+  formula_path, artifact = ARGV
+  needle = %q{url "file://#{ENV.fetch("CODEX_RELEASE_LOCAL_ARTIFACT")}"}
+  replacement = "url #{("file://" + artifact).dump}"
+  contents = File.read(formula_path)
+  abort "Generated formula does not contain local artifact URL placeholder" unless contents.include?(needle)
+  File.write(formula_path, contents.sub(needle, replacement))
+' "$temp_tap_dir/Formula/codex-release.rb" "$artifact"
+local_formula_token="$temp_tap_name/codex-release"
+
+if brew list --formula codex-release >/dev/null 2>&1; then
+    brew reinstall --formula --force "$local_formula_token"
+else
+    brew install --formula "$local_formula_token"
+fi
+
+brew test "$local_formula_token"
+install_succeeded=1


### PR DESCRIPTION
## Summary
- add `make codex` / `make codex-release-local` for local Codex CLI release installs
- add a Dagger `codexReleaseLocalBundle` function that accepts a locally built tarball
- write local bundles to `dist/codex-release-local/` and support existing tarballs via `CODEX_RELEASE_ARTIFACT`

## Validation
- `bash -n scripts/install-codex-release-local.sh`
- `npm test --prefix dagger/tap-pipeline` (40/40)
- fake artifact smoke: `scripts/install-codex-release-local.sh --artifact ... --skip-install`
- `git diff --check`