### PR TITLE
Fix local Codex release builder

### DIFF
--- a/Formula/codex-release.rb
+++ b/Formula/codex-release.rb
@@ -13,8 +13,6 @@ class CodexRelease < Formula
 
   depends_on :linux
 
-  conflicts_with "codex", because: "both install a codex executable"
-
   def install
     libexec.install Dir["*"]
 
@@ -31,6 +29,7 @@ class CodexRelease < Formula
 
       The unique formula name keeps it separate from any upstream `codex` package,
       but the installed executable stays `codex`.
+      Uninstall the official `codex` cask first if it already owns that executable.
     EOS
   end
 

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ codex --help
 ```
 
 The formula token is `codex-release` so it does not collide with upstream, but it
-installs the `codex` executable and declares a conflict with any upstream `codex`
-formula that also owns that binary.
+installs the `codex` executable. Uninstall the official `codex` cask first if it
+already owns that binary.
 
 For fast local iteration, build the Codex asset locally and install it through a
 temporary local tap:

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -185,10 +185,11 @@ test("codex release tracks the fork tap-release branch and installs codex", () =
 
   const formula = readFileSync(new URL("../../../Formula/codex-release.rb", import.meta.url), "utf8")
 
-  assert.match(formula, /conflicts_with "codex"/)
+  assert.doesNotMatch(formula, /conflicts_with "codex"/)
   assert.match(formula, /libexec\.install Dir\["\*"\]/)
   assert.match(formula, /exec "#\{libexec\}\/bin\/codex" "\$@"/)
   assert.match(formula, /tap-release branch/)
+  assert.match(formula, /official `codex` cask/)
 })
 
 test("codex release bundle consumes the fork's Linux release asset instead of compiling", () => {

--- a/scripts/build-codex-release-local.sh
+++ b/scripts/build-codex-release-local.sh
@@ -118,6 +118,28 @@ source_dir="$(absolute_path "$source_dir")"
 cache_dir="$(absolute_path "$cache_dir")"
 output_dir="$(absolute_path "$output_dir")"
 
+repair_podman_userns_ownership() {
+    local path="$1"
+
+    [ -e "$path" ] || return 0
+    [ -O "$path" ] && [ -w "$path" ] && return 0
+    command -v podman >/dev/null 2>&1 || return 0
+
+    # Rootless Podman subuid ownership can leak onto bind mounts if an older
+    # builder chowned files inside the user namespace. In `podman unshare`,
+    # 0:0 maps back to the invoking host user.
+    podman unshare chown -R 0:0 "$path" 2>/dev/null || true
+}
+
+remove_path() {
+    local path="$1"
+
+    [ -e "$path" ] || return 0
+    rm -rf "$path" 2>/dev/null && return 0
+    repair_podman_userns_ownership "$path"
+    rm -rf "$path"
+}
+
 prepare_source() {
     if ! command -v git >/dev/null 2>&1; then
         echo "git is required to fetch Codex source." >&2
@@ -125,13 +147,13 @@ prepare_source() {
     fi
 
     if [ "$clean_source" -eq 1 ]; then
-        rm -rf "$source_dir"
+        remove_path "$source_dir"
     fi
 
     mkdir -p "$(dirname "$source_dir")"
 
     if [ ! -d "$source_dir/.git" ]; then
-        rm -rf "$source_dir"
+        remove_path "$source_dir"
         git clone --filter=blob:none --no-tags "$source_repo" "$source_dir"
     else
         git -C "$source_dir" remote set-url origin "$source_repo"
@@ -190,8 +212,6 @@ run_in_container() {
         --rm
         -t
         -e CODEX_RELEASE_INSIDE_CONTAINER=1
-        -e HOST_UID="$(id -u)"
-        -e HOST_GID="$(id -g)"
         -v "$source_dir:/source"
         -v "$cache_dir:/cache"
         -v "$output_dir:/output"
@@ -214,9 +234,11 @@ run_in_container() {
 
 if [ "$inside_container" != "1" ]; then
     prepare_source
+    repair_podman_userns_ownership "$cache_dir"
+    repair_podman_userns_ownership "$output_dir"
 
     if [ "$clean_cache" -eq 1 ]; then
-        rm -rf "$cache_dir"
+        remove_path "$cache_dir"
     fi
 
     if [ "$use_container" != "false" ]; then
@@ -232,7 +254,7 @@ if [ "$inside_container" != "1" ]; then
 fi
 
 if [ "$clean_cache" -eq 1 ]; then
-    rm -rf "$cache_dir"
+    remove_path "$cache_dir"
 fi
 
 mkdir -p "$cache_dir" "$output_dir"
@@ -292,10 +314,6 @@ python3 "$source_dir/scripts/build_codex_package.py" \
 sha256sum "$archive_path" | tee "$archive_path.sha256"
 cp "$CARGO_TARGET_DIR/$target/release/codex" "$output_dir/codex"
 cp "$CARGO_TARGET_DIR/$target/release/bwrap" "$output_dir/bwrap"
-
-if [ -n "${HOST_UID:-}" ] && [ -n "${HOST_GID:-}" ] && [ "$(id -u)" = "0" ]; then
-    chown -R "$HOST_UID:$HOST_GID" "$cache_dir" "$output_dir"
-fi
 
 cat <<EOF
 Built local Codex release asset.


### PR DESCRIPTION
## Summary
- repair rootless Podman-owned local builder paths before cleanup/reuse
- stop forcing HOST_UID/HOST_GID ownership from inside the builder container
- keep codex-release separate from official Codex cask without declaring a bad formula conflict

## Tests
- npm test --prefix dagger/tap-pipeline
- bash -n scripts/build-codex-release-local.sh scripts/install-codex-release-local.sh
- git diff --check
- CODEX_RELEASE_SOURCE_REPO=file:///var/home/kdlocpanda/second_brain/Resources/codex-memory-lab/codex CODEX_RELEASE_REF=tap-release make codex