### PR TITLE
[codex] Make auto-update probes resilient

### DIFF
--- a/.github/workflows/tap-auto-update.yml
+++ b/.github/workflows/tap-auto-update.yml
@@ -123,12 +123,14 @@ jobs:
           echo
           echo "### Package Status"
           echo
-          jq -r '.[] | "- \(.id): current=\(.current_version) upstream=\(.upstream_version) needs_update=\(.needs_update)"' <<<"$STATUS_JSON"
+          jq -r '.[] | if .skipped then "- \(.id): current=\(.current_version) upstream=unknown needs_update=false skipped=true reason=\(.skip_reason)" else "- \(.id): current=\(.current_version) upstream=\(.upstream_version) needs_update=\(.needs_update)" end' <<<"$STATUS_JSON"
         } >> "$GITHUB_STEP_SUMMARY"
 
-        echo "package_ids_json=$PACKAGE_IDS_JSON" >> "$GITHUB_OUTPUT"
-        echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-        echo "has_packages=$([ "$count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        {
+          echo "package_ids_json=$PACKAGE_IDS_JSON"
+          echo "matrix=$matrix"
+          echo "has_packages=$([ "$count" -gt 0 ] && echo true || echo false)"
+        } >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -7,7 +7,9 @@ import {
   parseAutoUpdateSlotId,
   packagesForAutoUpdateSlot as slotPackages,
   formatGitHeadVersion,
+  isTransientUpstreamProbeError,
   releaseMetadataForPackage,
+  TransientUpstreamProbeError,
 } from "./library.js"
 import { rewriteCaskUrl } from "./cask-render.js"
 import { renderGithubApiFetchScript } from "./github-api.js"
@@ -351,14 +353,25 @@ type CodexDesktopDmgMetadata = {
   version: string
 }
 
+type CodexDesktopDmgProbeResult =
+  | ({ ok: true } & Omit<CodexDesktopDmgMetadata, "version">)
+  | {
+      ok: false
+      reason: string
+      sourceUrl: string
+      transient: true
+    }
+
 type AutoUpdatePackageStatus = {
   id: string
   kind: string
   homebrew_path: string
   current_version: string
-  upstream_version: string
+  upstream_version: string | null
   current_release_published: boolean
   needs_update: boolean
+  skipped?: boolean
+  skip_reason?: string
 }
 
 @object()
@@ -419,8 +432,28 @@ export class TapPipeline {
     const entries = slotPackages(parseAutoUpdateSlotId(slotId))
     const statuses = await Promise.all(entries.map(async (entry): Promise<AutoUpdatePackageStatus> => {
       const currentVersion = await this.currentPackagedVersion(entry.id)
-      const upstreamVersion = await this.resolveUpstreamVersion(entry.id, codexDesktopConversionCommit)
       const currentReleasePublished = await this.tapReleaseExists(entry.id, currentVersion)
+
+      let upstreamVersion: string
+      try {
+        upstreamVersion = await this.resolveUpstreamVersion(entry.id, codexDesktopConversionCommit)
+      } catch (error) {
+        if (isTransientUpstreamProbeError(error)) {
+          return {
+            id: entry.id,
+            kind: entry.kind,
+            homebrew_path: entry.homebrewPath,
+            current_version: currentVersion,
+            upstream_version: null,
+            current_release_published: currentReleasePublished,
+            needs_update: false,
+            skipped: true,
+            skip_reason: error.message,
+          }
+        }
+
+        throw error
+      }
 
       return {
         id: entry.id,
@@ -458,9 +491,41 @@ export class TapPipeline {
         [
           "import { createHash } from 'node:crypto'",
           "const sourceUrl = process.argv[1]",
-          "const response = await fetch(sourceUrl, { method: 'HEAD', redirect: 'follow' })",
-          "if (!response.ok) {",
-          "  throw new Error(`Failed to resolve ${sourceUrl}: ${response.status}`)",
+          "async function probe(url) {",
+          "  const attempts = [",
+          "    { method: 'HEAD', timeout: 10_000 },",
+          "    { method: 'HEAD', timeout: 20_000 },",
+          "    { method: 'GET', timeout: 20_000 },",
+          "  ]",
+          "  let lastError",
+          "  for (const attempt of attempts) {",
+          "    try {",
+          "      const response = await fetch(url, {",
+          "        method: attempt.method,",
+          "        redirect: 'follow',",
+          "        signal: AbortSignal.timeout(attempt.timeout),",
+          "      })",
+          "      if (!response.ok) {",
+          "        throw new Error(`Failed to resolve ${url}: ${response.status} ${response.statusText}`)",
+          "      }",
+          "      return response",
+          "    } catch (error) {",
+          "      lastError = error",
+          "    }",
+          "  }",
+          "  throw lastError",
+          "}",
+          "let response",
+          "try {",
+          "  response = await probe(sourceUrl)",
+          "} catch (error) {",
+          "  process.stdout.write(JSON.stringify({",
+          "    ok: false,",
+          "    transient: true,",
+          "    sourceUrl,",
+          "    reason: error instanceof Error ? `${error.name}: ${error.message}` : String(error),",
+          "  }))",
+          "  process.exit(0)",
           "}",
           "const normalizedHeader = (name, fallback) => {",
           "  const value = response.headers.get(name)",
@@ -473,6 +538,7 @@ export class TapPipeline {
           "  .update(`${lastModified}|${etag}|${contentLength}\\n`)",
           "  .digest('hex')",
           "process.stdout.write(JSON.stringify({",
+          "  ok: true,",
           "  sourceUrl,",
           "  resolvedUrl: response.url,",
           "  lastModified,",
@@ -483,10 +549,19 @@ export class TapPipeline {
         ].join("\n"),
         sourceUrl,
       ])
-      .stdout()).trim()) as Omit<CodexDesktopDmgMetadata, "version">
+      .stdout()).trim()) as CodexDesktopDmgProbeResult
+
+    if (!raw.ok) {
+      throw new TransientUpstreamProbeError(`Skipped upstream probe for ${sourceUrl}: ${raw.reason}`)
+    }
 
     return {
-      ...raw,
+      cacheSegment: raw.cacheSegment,
+      contentLength: raw.contentLength,
+      etag: raw.etag,
+      lastModified: raw.lastModified,
+      resolvedUrl: raw.resolvedUrl,
+      sourceUrl: raw.sourceUrl,
       version: codexDesktopPackageVersion(
         `dmg.${compactHttpTimestamp(raw.lastModified)}.${raw.cacheSegment.slice(0, 12)}`,
         conversionCommit,

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -10,6 +10,17 @@ type GitHeadVersionInput = {
   shaLength?: number
 }
 
+export class TransientUpstreamProbeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "TransientUpstreamProbeError"
+  }
+}
+
+export function isTransientUpstreamProbeError(error: unknown): error is TransientUpstreamProbeError {
+  return error instanceof TransientUpstreamProbeError
+}
+
 function compactUtcTimestamp(value: string): string {
   const date = new Date(value)
 

--- a/dagger/tap-pipeline/tests/planner.test.ts
+++ b/dagger/tap-pipeline/tests/planner.test.ts
@@ -6,9 +6,11 @@ import {
   PACKAGE_REGISTRY,
   changedCiPackagesFromPaths,
   changedPackagesFromPaths,
+  isTransientUpstreamProbeError,
   listAutoUpdateSlots,
   packagesForAutoUpdateSlot,
   platformPathsChanged,
+  TransientUpstreamProbeError,
 } from "../src/library.ts"
 
 test("listAutoUpdateSlots returns the stable slot order", () => {
@@ -74,4 +76,12 @@ test("platformPathsChanged detects shared orchestration changes", () => {
   assert.equal(platformPathsChanged(["dagger/tap-pipeline/src/index.ts"]), true)
   assert.equal(platformPathsChanged(["scripts/apply-release-bundle.mjs"]), true)
   assert.equal(platformPathsChanged(["README.md"]), false)
+})
+
+test("transient upstream probe errors are explicitly marked", () => {
+  assert.equal(
+    isTransientUpstreamProbeError(new TransientUpstreamProbeError("Skipped upstream probe for package")),
+    true,
+  )
+  assert.equal(isTransientUpstreamProbeError(new Error("ordinary failure")), false)
 })


### PR DESCRIPTION
## What changed

- Added retry and timeout handling to the Codex Desktop upstream DMG probe in the tap Dagger pipeline.
- Falls back from `HEAD` to `GET` when probing upstream URLs.
- Marks transient upstream probe failures as skipped package status instead of failing the whole scheduled slot.
- Shows skipped probe status and reason in the auto-update workflow summary.
- Added test coverage for transient upstream probe error classification.

## Why

Scheduled auto-update runs were failing when a single external upstream URL probe timed out in GitHub Actions. That made the whole slot fail even though the failure was transient and package-specific.

## Validation

- `npm test --prefix dagger/tap-pipeline`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tap-auto-update.yml"); puts "tap-auto-update.yml OK"'`
- `git diff --check`
- `actionlint .github/workflows/tap-auto-update.yml`