### PR TITLE
[codex] Use Debian 7zip for Codex desktop build

### DIFF
--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -761,12 +761,7 @@ export class TapPipeline {
         [
           "set -euo pipefail",
           "apt-get update",
-          "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl file g++ git jq make pkg-config python3 p7zip-full sudo tar unzip xz-utils",
-          "mkdir -p /root/.local/bin",
-          "curl -fsSL https://www.7-zip.org/a/7z2600-linux-x64.tar.xz -o /tmp/7z-linux-x64.tar.xz",
-          "tar -C /root/.local/bin -xf /tmp/7z-linux-x64.tar.xz 7zz",
-          "chmod 755 /root/.local/bin/7zz",
-          "rm -f /tmp/7z-linux-x64.tar.xz",
+          "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends 7zip ca-certificates curl file g++ git jq make pkg-config python3 p7zip-full sudo tar unzip xz-utils",
           "npm install -g node-gyp",
           "rm -rf /var/lib/apt/lists/*",
         ].join("\n"),

--- a/dagger/tap-pipeline/tests/codex-desktop.test.ts
+++ b/dagger/tap-pipeline/tests/codex-desktop.test.ts
@@ -668,8 +668,8 @@ test("codex desktop is local-only and not published by tap automation", () => {
   assert.match(pipeline, /depends_on formula: "desktop-file-utils"/)
   assert.match(pipeline, /brew install --cask test\/tap\/codex-desktop/)
   assert.match(pipeline, /patch-codex-desktop-conversion\.mjs/)
-  assert.match(pipeline, /7z2600-linux-x64\.tar\.xz/)
-  assert.match(pipeline, /tar -C \/root\/\.local\/bin -xf \/tmp\/7z-linux-x64\.tar\.xz 7zz/)
+  assert.match(pipeline, /--no-install-recommends 7zip ca-certificates/)
+  assert.doesNotMatch(pipeline, /7z2600-linux-x64\.tar\.xz/)
   assert.ok(
     pipeline.indexOf('if (packageId === "codex-desktop-linux")') <
       pipeline.indexOf("const ciLog = await this.ciCheck(packageId, githubToken)"),


### PR DESCRIPTION
## Summary

Use Debian's `7zip` package to provide `7zz` in the Codex Desktop Dagger build image.

## Why

The previous fix downloaded `7zz` directly from `www.7-zip.org`, but the Dagger container can fail to reach that host. Debian bookworm ships a separate `7zip` package that provides `/usr/bin/7zz`; `p7zip-full` only provides the p7zip-flavored `/usr/bin/7z`, which the conversion installer rejects for APFS DMG extraction.

## Validation

- `docker run --rm node:24-bookworm ... apt-get install ... 7zip ... command -v 7zz` confirms `/usr/bin/7zz`
- `npm test -- --runInBand codex-desktop` in a clean temporary worktree with this patch applied: 41 passed

## Notes

The local working tree still has unrelated, unstaged changes to `codex-desktop-conversion.ref` and an untracked `.serena/` directory; they are not included in this PR.
