### PR TITLE
Add Devsy CLI and Desktop packages

### DIFF
--- a/.github/workflows/tap-auto-update.yml
+++ b/.github/workflows/tap-auto-update.yml
@@ -5,6 +5,7 @@ on:
   - cron: "0 6 * * *"
   - cron: "0 7 * * *"
   - cron: "0 8 * * *"
+  - cron: "0 9 * * *"
   - cron: "17 0,6,12,18 * * *"
   - cron: "27 0,6,12,18 * * *"
   - cron: "17 2,4,8,10,14,16,20,22 * * *"
@@ -25,6 +26,7 @@ on:
         - vscode-insiders-2h
         - t3-daily
         - t3-code-6h
+        - devsy-daily
         - fizzy-daily
 
 permissions:
@@ -71,6 +73,7 @@ jobs:
             "0 6 * * *") slot_id="rcc-daily" ;;
             "0 7 * * *") slot_id="action-server-daily" ;;
             "0 8 * * *") slot_id="fizzy-daily" ;;
+            "0 9 * * *") slot_id="devsy-daily" ;;
             "17 0,6,12,18 * * *") slot_id="desktop-6h" ;;
             "27 0,6,12,18 * * *") slot_id="devpod-6h" ;;
             "17 2,4,8,10,14,16,20,22 * * *") slot_id="vscode-insiders-2h" ;;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,21 @@ Match the existing style: 2-space indentation in Ruby, JavaScript, and TypeScrip
 ## Testing Guidelines
 Every version bump or packaging change should include a local `brew install` or `brew test`, plus the relevant Dagger smoke test for artifact-based packages. Keep smoke coverage focused on the real install path: package artifact, install through Linuxbrew, verify binaries, and check desktop integration files when applicable.
 
+When an upstream Desktop artifact embeds a CLI that is also packaged as a formula, extract
+the artifact and verify the embedded binary before choosing install identities. Keep the
+formula-owned CLI and cask-owned launcher names distinct, do not link the embedded CLI from
+the cask, and make the package CI install both artifacts together to prove their Homebrew
+paths coexist.
+
+For Devsy on Bluefin or Fedora bootc, keep channel selection explicit and deterministic:
+Homebrew owns the CLI path, while the Homebrew AppImage cask and upstream Flatpak bundle are
+parallel first-class Desktop choices with different package-manager lifecycles. Never rank
+one Desktop channel as the Bluefin default, auto-detect the host to switch package managers,
+or make a cask invoke or own Flatpak. Recommend RPM only when it is deliberately baked into
+a custom bootc image, not for ad hoc host layering.
+The Devsy AppImage embeds AppIndicator/StatusNotifier and libnotify support, so do not add
+the DevPod AppIndicator runtime formula without new runtime evidence.
+
 ## Commit & Pull Request Guidelines
 Follow the existing history: short imperative subjects like `Update devpod-linux cask to v0.17.0` or `Package VS Code Insiders from the Linux RPM (#12)`. PRs should explain what changed, link the upstream release or source commit, and note any updated SHA256 values. Include command output for `dagger ... smoke-test` or `brew audit` in the PR description. Add screenshots only when launcher, icon, or protocol-handler behavior changes.
 

--- a/Casks/devsy-desktop.rb
+++ b/Casks/devsy-desktop.rb
@@ -1,0 +1,88 @@
+cask "devsy-desktop" do
+  arch intel: "x86_64"
+  os linux: "linux"
+
+  version "1.6.1"
+  sha256 x86_64_linux: "615df0c58da5a700aa47ba461c9d9f9497b5a76cc254af694e1167a383a5fb47"
+
+  url "https://github.com/devsy-org/devsy/releases/download/v1.6.1/Devsy_linux_x86_64.AppImage"
+  name "Devsy"
+  desc "Desktop interface for the Devsy development environment platform"
+  homepage "https://devsy.sh/"
+
+  livecheck do
+    skip "Updated by the tap's GitHub Actions workflow."
+  end
+
+  depends_on arch: :x86_64
+
+  container type: :naked
+
+  binary "devsy-desktop-wrapper", target: "devsy-desktop"
+  artifact "devsy-desktop.desktop",
+           target: "#{Dir.home}/.local/share/applications/devsy-desktop.desktop"
+  artifact "devsy-desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/128x128/apps/devsy-desktop.png"
+
+  preflight do
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/128x128/apps"
+
+    appimage = "#{staged_path}/Devsy_linux_#{arch}.AppImage"
+    system "chmod", "+x", appimage
+    system appimage, "--appimage-extract", chdir: staged_path, out: File::NULL
+
+    desktop_source = "#{staged_path}/squashfs-root/devsy-desktop.desktop"
+    raise "No desktop entry found in extracted Devsy AppImage" unless File.file?(desktop_source)
+
+    desktop_contents = File.read(desktop_source)
+    desktop_contents.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/devsy-desktop %U")
+    desktop_contents.gsub!(
+      /^Icon=.*/,
+      "Icon=#{Dir.home}/.local/share/icons/hicolor/128x128/apps/devsy-desktop.png"
+    )
+    File.write("#{staged_path}/devsy-desktop.desktop", desktop_contents)
+
+    icon_source = "#{staged_path}/squashfs-root/usr/share/icons/hicolor/128x128/apps/devsy-desktop.png"
+    raise "No 128x128 icon found in extracted Devsy AppImage" unless File.file?(icon_source)
+
+    FileUtils.cp(icon_source, "#{staged_path}/devsy-desktop.png")
+
+    wrapper = "#{staged_path}/devsy-desktop-wrapper"
+    File.write(wrapper, <<~SH)
+      #!/bin/bash
+      exec "#{appimage}" "$@"
+    SH
+    FileUtils.chmod 0755, wrapper
+  end
+
+  postflight do
+    applications_dir = "#{Dir.home}/.local/share/applications"
+    desktop_id = "devsy-desktop.desktop"
+    xdg_mime = ["/usr/bin/xdg-mime", "/bin/xdg-mime", "#{HOMEBREW_PREFIX}/bin/xdg-mime"]
+      .find { |candidate| File.executable?(candidate) }
+    update_desktop_database = [
+      "/usr/bin/update-desktop-database",
+      "/bin/update-desktop-database",
+      "#{HOMEBREW_PREFIX}/bin/update-desktop-database",
+    ].find { |candidate| File.executable?(candidate) }
+
+    system xdg_mime, "default", desktop_id, "x-scheme-handler/devsy" if xdg_mime
+    system update_desktop_database, applications_dir if update_desktop_database
+  end
+
+  zap trash: [
+    "#{Dir.home}/.local/share/applications/devsy-desktop.desktop",
+    "#{Dir.home}/.local/share/icons/hicolor/128x128/apps/devsy-desktop.png",
+  ]
+
+  caveats <<~EOS
+    Launch the desktop app with:
+      devsy-desktop
+
+    The AppImage contains an internal Devsy CLI used by the desktop app, but
+    this cask does not expose it on PATH. Install the independently versioned
+    CLI formula when you want the devsy command:
+      brew install joshyorko/tools/devsy
+  EOS
+end

--- a/Formula/devsy.rb
+++ b/Formula/devsy.rb
@@ -1,0 +1,37 @@
+class Devsy < Formula
+  desc "Development environment platform for containers and Kubernetes"
+  homepage "https://devsy.sh/"
+  version "1.6.1"
+  license "MPL-2.0"
+
+  livecheck do
+    skip "Updated by the tap's GitHub Actions workflow."
+  end
+
+  depends_on :linux
+
+  on_linux do
+    on_intel do
+      url "https://github.com/devsy-org/devsy/releases/download/v1.6.1/devsy-linux-amd64"
+      sha256 "9d833b914b6a57f6c5dedb898464dd2d789838bba23e7ad874eb2e6385183ee5"
+    end
+
+    on_arm do
+      url "https://github.com/devsy-org/devsy/releases/download/v1.6.1/devsy-linux-arm64"
+      sha256 "35bd019a5e9c394050497c39eed4ebb3f17d7356220c7714edee23354c5204bb"
+    end
+  end
+
+  def install
+    binary = Dir["devsy-linux-*"].first
+    raise "Devsy release binary was not downloaded" unless binary
+
+    chmod 0755, binary
+    bin.install binary => "devsy"
+  end
+
+  test do
+    ENV["DEVSY_HOME"] = testpath.to_s
+    assert_equal "v#{version}\n", shell_output("#{bin}/devsy --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ An automation runtime for creating isolated, reproducible environments. Fork of 
 | `brew install joshyorko/tools/t3code-cli-main` | Install T3 Code CLI from `main` |
 | `brew install joshyorko/tools/codex-release` | Install Codex CLI from Josh Yorko's tap-release branch fork; executable remains `codex` |
 | `brew install joshyorko/tools/antigravity-cli` | Install Google Antigravity CLI for Linux x64; executable is `agy` |
+| `brew install joshyorko/tools/devsy` | Install the stable Devsy CLI for Linux x64 or arm64 |
+| `brew install --cask joshyorko/tools/devsy-desktop` | Install Devsy Desktop for Linux x64 |
 | `brew install joshyorko/tools/fizzy-cli-master` | Install Fizzy CLI from upstream `master` |
 | `brew install joshyorko/tools/fizzy-symphony` | Install Fizzy Symphony from `main` |
 | `brew install joshyorko/tools/eitype` | Install Eitype |
@@ -255,6 +257,72 @@ launcher.
 > ```
 
 Run `agy install` after installation if you want Antigravity's own shell setup.
+
+### Devsy CLI and Desktop
+
+Devsy is packaged as two required, co-installable Homebrew identities from the same
+pinned stable upstream release:
+
+- `devsy` is the CLI formula. Homebrew deterministically selects the verified raw
+  Linux amd64 or arm64 binary for the current CPU and exposes `devsy`.
+- `devsy-desktop` is the first-class Linux x86_64 AppImage cask. It exposes only
+  `devsy-desktop`, a desktop entry, an icon, and the `devsy://` protocol handler.
+  It is intentionally unsupported on arm64 and fails there instead of substituting
+  Flatpak, RPM, or another package manager.
+
+```bash
+brew install joshyorko/tools/devsy
+devsy --version
+
+brew install --cask joshyorko/tools/devsy-desktop
+devsy-desktop
+```
+
+The pinned AppImage contains its own byte-identical amd64 CLI at
+`resources/bin/devsy` for internal Desktop use. The cask deliberately does not link
+that embedded binary into Homebrew's `bin`, so it does not replace or shadow the
+formula-owned `devsy` command. Both packages are MPL-2.0 upstream artifacts.
+
+On Bluefin and Fedora bootc systems, the Homebrew AppImage cask and upstream Flatpak
+bundle are parallel first-class Desktop choices. Homebrew provides tap-controlled
+updates and direct host-tool access; Flatpak provides its own isolated lifecycle and
+upstream host-reexec wrapper. The operator's command always selects the channel; this
+tap never ranks one as the default, never auto-detects Bluefin, and never invokes or
+owns Flatpak. RPM is appropriate when deliberately baked into a custom bootc image,
+not for ad hoc host layering.
+
+To explicitly select the upstream-owned Flatpak channel, choose an exact stable tag
+from the [Devsy releases](https://github.com/devsy-org/devsy/releases), then download
+and verify that release's GitHub-published digest before installing it:
+
+```bash
+DEVSY_TAG=vX.Y.Z
+curl -fL -o Devsy.flatpak \
+  "https://github.com/devsy-org/devsy/releases/download/${DEVSY_TAG}/Devsy.flatpak"
+curl -fsSL "https://api.github.com/repos/devsy-org/devsy/releases/tags/${DEVSY_TAG}" \
+  | jq -r '.assets[] | select(.name == "Devsy.flatpak") | .digest + "  Devsy.flatpak"' \
+  | sed 's/^sha256://' \
+  | sha256sum -c -
+flatpak install --user ./Devsy.flatpak
+```
+
+The AppImage bundles `libnotify.so.4`, `libXss.so.1`, `libXtst.so.6`,
+`libappindicator.so.1`, and its StatusNotifier implementation. FUSE, GTK3, NSS,
+AT-SPI, and `xdg-utils` remain host runtime requirements. Bluefin runtime validation
+confirmed a Wayland window, active StatusNotifier tray item and menu, protocol launch,
+sandboxed Electron renderer, formula/cask coexistence, and a clean exit. The embedded
+AppIndicator support means this package must not inherit DevPod's separate
+AppIndicator runtime formula.
+
+The `devsy-daily` updater alone resolves GitHub's time-dependent `latest`
+non-prerelease release. Each published formula and cask is then pinned to an exact
+version, tag commit, asset name, and SHA-256, mirrored through an immutable tap release,
+and updated independently.
+
+```bash
+dagger -m ./dagger/tap-pipeline call ci-check --package-id=devsy
+dagger -m ./dagger/tap-pipeline call ci-check --package-id=devsy-desktop
+```
 
 ### Codex Desktop (Linux DMG Conversion Runtime)
 
@@ -641,6 +709,8 @@ Add to your `Brewfile`:
 ```ruby
 tap "joshyorko/tools"
 cask "rcc"
+brew "devsy"
+cask "devsy-desktop"
 ```
 
 Or with the full path:

--- a/dagger/tap-pipeline/auto-update-slots.json
+++ b/dagger/tap-pipeline/auto-update-slots.json
@@ -35,6 +35,11 @@
     "packageIds": ["t3-code-linux"]
   },
   {
+    "id": "devsy-daily",
+    "description": "Daily stable Devsy CLI and Linux desktop refresh.",
+    "packageIds": ["devsy", "devsy-desktop"]
+  },
+  {
     "id": "fizzy-daily",
     "description": "Daily refresh for Fizzy CLI upstream master, fizzy-popper self-hosted, and fizzy-symphony main.",
     "packageIds": ["fizzy-cli-master", "fizzy-popper-self-hosted", "fizzy-symphony"]

--- a/dagger/tap-pipeline/src/devsy-render.ts
+++ b/dagger/tap-pipeline/src/devsy-render.ts
@@ -1,0 +1,104 @@
+export const DEVSY_AMD64_ASSET = "devsy-linux-amd64"
+export const DEVSY_ARM64_ASSET = "devsy-linux-arm64"
+export const DEVSY_DESKTOP_ASSET = "Devsy_linux_x86_64.AppImage"
+
+export type DevsyReleaseAsset = {
+  name: string
+  browser_download_url: string
+  digest: string | null
+}
+
+export type DevsyRelease = {
+  draft: boolean
+  prerelease: boolean
+  tag_name: string
+  assets: DevsyReleaseAsset[]
+}
+
+export type ResolvedDevsyRelease = {
+  version: string
+  upstreamTag: string
+  amd64: DevsyReleaseAsset
+  arm64: DevsyReleaseAsset
+  desktop: DevsyReleaseAsset
+}
+
+function requireAsset(release: DevsyRelease, name: string): DevsyReleaseAsset {
+  const asset = release.assets.find((candidate) => candidate.name === name)
+
+  if (!asset) {
+    throw new Error(`Stable Devsy release is missing ${name}`)
+  }
+
+  const expectedUrl = `https://github.com/devsy-org/devsy/releases/download/${release.tag_name}/${name}`
+  if (asset.browser_download_url !== expectedUrl) {
+    throw new Error(`Devsy release asset ${name} has unexpected URL ${asset.browser_download_url}`)
+  }
+
+  return asset
+}
+
+export function resolveStableDevsyRelease(release: DevsyRelease): ResolvedDevsyRelease {
+  if (release.draft || release.prerelease || !/^v\d+\.\d+\.\d+$/.test(release.tag_name)) {
+    throw new Error(`Expected a stable semantic Devsy release, received ${release.tag_name}`)
+  }
+
+  return {
+    version: release.tag_name.slice(1),
+    upstreamTag: release.tag_name,
+    amd64: requireAsset(release, DEVSY_AMD64_ASSET),
+    arm64: requireAsset(release, DEVSY_ARM64_ASSET),
+    desktop: requireAsset(release, DEVSY_DESKTOP_ASSET),
+  }
+}
+
+export function verifyDevsyGithubDigest(asset: DevsyReleaseAsset, sha256: string): void {
+  const expected = asset.digest?.match(/^sha256:([a-f0-9]{64})$/)?.[1]
+
+  if (!expected) {
+    throw new Error(`Devsy release asset ${asset.name} is missing a GitHub SHA-256 digest`)
+  }
+
+  if (sha256 !== expected) {
+    throw new Error(`GitHub digest mismatch for ${asset.name}: expected ${expected}, received ${sha256}`)
+  }
+}
+
+export function renderDevsyFormula(
+  baseContents: string,
+  update: {
+    version: string
+    amd64Sha256: string
+    arm64Sha256: string
+    amd64Url: string
+    arm64Url: string
+  },
+): string {
+  return baseContents
+    .replace(/version ".*"/, `version "${update.version}"`)
+    .replace(
+      /url "[^"]*devsy-linux-amd64"\n\s+sha256 "[^"]+"/,
+      `url "${update.amd64Url}"\n      sha256 "${update.amd64Sha256}"`,
+    )
+    .replace(
+      /url "[^"]*devsy-linux-arm64"\n\s+sha256 "[^"]+"/,
+      `url "${update.arm64Url}"\n      sha256 "${update.arm64Sha256}"`,
+    )
+}
+
+export function renderDevsyDesktopCask(
+  baseContents: string,
+  update: {
+    version: string
+    sha256: string
+    downloadUrl: string
+  },
+  rewriteUrl: (contents: string, downloadUrl: string) => string,
+): string {
+  return rewriteUrl(
+    baseContents
+      .replace(/version ".*"/, `version "${update.version}"`)
+      .replace(/sha256 x86_64_linux: (?::no_check|".*")/, `sha256 x86_64_linux: "${update.sha256}"`),
+    update.downloadUrl,
+  )
+}

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -12,6 +12,14 @@ import {
   TransientUpstreamProbeError,
 } from "./library.js"
 import { rewriteCaskUrl } from "./cask-render.js"
+import {
+  DevsyRelease,
+  DevsyReleaseAsset,
+  renderDevsyDesktopCask,
+  renderDevsyFormula,
+  resolveStableDevsyRelease,
+  verifyDevsyGithubDigest,
+} from "./devsy-render.js"
 import { renderGithubApiFetchScript } from "./github-api.js"
 
 const TAP_DIR = "/tap"
@@ -188,6 +196,17 @@ function tapStagingCommands(packageId: string): string[] {
       return [
         "mkdir -p \"$tap_dir/Formula\"",
         "cp /tap/Formula/antigravity-cli.rb \"$tap_dir/Formula/\"",
+      ]
+    case "devsy":
+      return [
+        "mkdir -p \"$tap_dir/Formula\"",
+        "cp /tap/Formula/devsy.rb \"$tap_dir/Formula/\"",
+      ]
+    case "devsy-desktop":
+      return [
+        "mkdir -p \"$tap_dir/Casks\" \"$tap_dir/Formula\"",
+        "cp /tap/Casks/devsy-desktop.rb \"$tap_dir/Casks/\"",
+        "cp /tap/Formula/devsy.rb \"$tap_dir/Formula/\"",
       ]
     case "fizzy-cli-master":
       return [
@@ -371,6 +390,23 @@ type ActionServerBuild = {
 type DevpodBuild = {
   version: string
   upstreamTag: string
+  container: Container
+  asset: DownloadedAsset
+}
+
+type DevsyCliBuild = {
+  version: string
+  upstreamTag: string
+  upstreamCommit: string
+  container: Container
+  amd64: DownloadedAsset
+  arm64: DownloadedAsset
+}
+
+type DevsyDesktopBuild = {
+  version: string
+  upstreamTag: string
+  upstreamCommit: string
   container: Container
   asset: DownloadedAsset
 }
@@ -719,6 +755,10 @@ export class TapPipeline {
         return `action-server-${version}`
       case "devpod-linux":
         return `devpod-linux-${version}`
+      case "devsy":
+        return `devsy-${version}`
+      case "devsy-desktop":
+        return `devsy-desktop-${version}`
       case "t3code-cli-main":
         return `t3code-cli-main-${version}`
       case "codex-release":
@@ -955,6 +995,52 @@ export class TapPipeline {
         assetName: build.asset.assetName,
         version: build.version,
         commit: build.upstreamTag,
+      },
+    })
+  }
+
+  private devsyCliReleaseMetadata(build: DevsyCliBuild): Record<string, unknown> {
+    return {
+      ...releaseMetadataForPackage("devsy", {
+        version: build.version,
+        releaseTag: `devsy-${build.version}`,
+        assetName: build.amd64.assetName,
+        artifactSha256: build.amd64.sha256,
+        downloadUrl: `https://github.com/${TAP_REPOSITORY}/releases/download/devsy-${build.version}/${build.amd64.assetName}`,
+        releaseTitle: `Devsy CLI ${build.version}`,
+        releaseNotes: `Verified CLI binaries mirrored from devsy-org/devsy ${build.upstreamTag} (${build.upstreamCommit})`,
+        commitMessage: `Update devsy formula to v${build.version}`,
+        upstream: {
+          kind: "github_release",
+          repo: "https://github.com/devsy-org/devsy",
+          assetPrefix: "devsy-linux-",
+          version: build.version,
+          commit: build.upstreamCommit,
+        },
+      }),
+      artifacts: [
+        { name: build.amd64.assetName, sha256: build.amd64.sha256 },
+        { name: build.arm64.assetName, sha256: build.arm64.sha256 },
+      ],
+    }
+  }
+
+  private devsyDesktopReleaseMetadata(build: DevsyDesktopBuild): Record<string, unknown> {
+    return releaseMetadataForPackage("devsy-desktop", {
+      version: build.version,
+      releaseTag: `devsy-desktop-${build.version}`,
+      assetName: build.asset.assetName,
+      artifactSha256: build.asset.sha256,
+      downloadUrl: `https://github.com/${TAP_REPOSITORY}/releases/download/devsy-desktop-${build.version}/${build.asset.assetName}`,
+      releaseTitle: `Devsy Desktop ${build.version}`,
+      releaseNotes: `Verified Linux AppImage mirrored from devsy-org/devsy ${build.upstreamTag} (${build.upstreamCommit})`,
+      commitMessage: `Update devsy-desktop cask to v${build.version}`,
+      upstream: {
+        kind: "github_release",
+        repo: "https://github.com/devsy-org/devsy",
+        assetName: build.asset.assetName,
+        version: build.version,
+        commit: build.upstreamCommit,
       },
     })
   }
@@ -2461,6 +2547,92 @@ end
     }
   }
 
+  private async resolveDevsyRelease(): Promise<DevsyRelease & { commit: string }> {
+    const release = await this.fetchJson("https://api.github.com/repos/devsy-org/devsy/releases/latest") as DevsyRelease
+
+    resolveStableDevsyRelease(release)
+
+    const ref = await this.fetchJson(
+      `https://api.github.com/repos/devsy-org/devsy/git/ref/tags/${encodeURIComponent(release.tag_name)}`,
+    ) as {
+      object: {
+        sha: string
+        type: "commit" | "tag"
+        url: string
+      }
+    }
+    let commit = ref.object.sha
+
+    if (ref.object.type === "tag") {
+      const tag = await this.fetchJson(ref.object.url) as { object: { sha: string } }
+      commit = tag.object.sha
+    }
+
+    return { ...release, commit }
+  }
+
+  private verifyGithubDigest(asset: DevsyReleaseAsset, sha256: string): void {
+    verifyDevsyGithubDigest(asset, sha256)
+  }
+
+  private async buildDevsyCliArtifacts(): Promise<DevsyCliBuild> {
+    const release = await this.resolveDevsyRelease()
+    const resolved = resolveStableDevsyRelease(release)
+    const amd64Asset = resolved.amd64
+    const arm64Asset = resolved.arm64
+
+    let container = this.githubApiContainer()
+    container = this.downloadAsset(container, amd64Asset.browser_download_url, `/tmp/${amd64Asset.name}`)
+    container = this.downloadAsset(container, arm64Asset.browser_download_url, `/tmp/${arm64Asset.name}`)
+    const amd64Sha256 = await this.sha256For(container, `/tmp/${amd64Asset.name}`)
+    const arm64Sha256 = await this.sha256For(container, `/tmp/${arm64Asset.name}`)
+    this.verifyGithubDigest(amd64Asset, amd64Sha256)
+    this.verifyGithubDigest(arm64Asset, arm64Sha256)
+
+    return {
+      version: resolved.version,
+      upstreamTag: resolved.upstreamTag,
+      upstreamCommit: release.commit,
+      container,
+      amd64: {
+        assetName: amd64Asset.name,
+        artifactPath: `/tmp/${amd64Asset.name}`,
+        sha256: amd64Sha256,
+        sourceUrl: amd64Asset.browser_download_url,
+      },
+      arm64: {
+        assetName: arm64Asset.name,
+        artifactPath: `/tmp/${arm64Asset.name}`,
+        sha256: arm64Sha256,
+        sourceUrl: arm64Asset.browser_download_url,
+      },
+    }
+  }
+
+  private async buildDevsyDesktopArtifact(): Promise<DevsyDesktopBuild> {
+    const release = await this.resolveDevsyRelease()
+    const resolved = resolveStableDevsyRelease(release)
+    const appImageAsset = resolved.desktop
+
+    let container = this.githubApiContainer()
+    container = this.downloadAsset(container, appImageAsset.browser_download_url, `/tmp/${appImageAsset.name}`)
+    const sha256 = await this.sha256For(container, `/tmp/${appImageAsset.name}`)
+    this.verifyGithubDigest(appImageAsset, sha256)
+
+    return {
+      version: resolved.version,
+      upstreamTag: resolved.upstreamTag,
+      upstreamCommit: release.commit,
+      container,
+      asset: {
+        assetName: appImageAsset.name,
+        artifactPath: `/tmp/${appImageAsset.name}`,
+        sha256,
+        sourceUrl: appImageAsset.browser_download_url,
+      },
+    }
+  }
+
   private async buildT3CodeArtifact(tap: Directory, ref: string, version?: string): Promise<T3CodeBuild> {
     const entry = this.packageEntry("t3-code-linux")
 
@@ -2661,6 +2833,29 @@ end
       /livecheck do\n(?:.*\n)*?\s+end\n/m,
       "livecheck do\n    skip \"Updated by the tap's GitHub Actions workflow.\"\n  end\n",
     )
+  }
+
+  private renderDevsyFormula(
+    baseContents: string,
+    build: DevsyCliBuild,
+    urls: { amd64: string; arm64: string },
+  ): string {
+    return renderDevsyFormula(baseContents, {
+      version: build.version,
+      amd64Sha256: build.amd64.sha256,
+      arm64Sha256: build.arm64.sha256,
+      amd64Url: urls.amd64,
+      arm64Url: urls.arm64,
+    })
+  }
+
+  private renderDevsyDesktopCask(
+    baseContents: string,
+    downloadUrl: string,
+    version: string,
+    sha256: string,
+  ): string {
+    return renderDevsyDesktopCask(baseContents, { version, sha256, downloadUrl }, rewriteCaskUrl)
   }
 
   private renderT3CodeCask(baseContents: string, downloadUrl: string, version: string, sha256: string): string {
@@ -2874,6 +3069,110 @@ end
               "brew test test/tap/antigravity-cli",
               "agy --version",
               "agy --help",
+            ].join("\n"),
+          ])
+          .stdout()
+      }
+      case "devsy": {
+        const build = await this.buildDevsyCliArtifacts()
+        const formulaContents = await tap.file("Formula/devsy.rb").contents()
+        const updatedFormula = this.renderDevsyFormula(formulaContents, build, {
+          amd64: `file:///artifacts/${build.amd64.assetName}`,
+          arm64: `file:///artifacts/${build.arm64.assetName}`,
+        })
+        const smokeTap = tap.withFile("Formula/devsy.rb", dag.file("devsy.rb", updatedFormula))
+
+        return dag
+          .container()
+          .from(BREW_IMAGE)
+          .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
+          .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
+          .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
+          .withDirectory("/tap", smokeTap)
+          .withFile(`/artifacts/${build.amd64.assetName}`, build.container.file(build.amd64.artifactPath))
+          .withFile(`/artifacts/${build.arm64.assetName}`, build.container.file(build.arm64.artifactPath))
+          .withExec([
+            "bash",
+            "-lc",
+            [
+              "set -euo pipefail",
+              "repo=$(brew --repository)",
+              "tap_dir=\"$repo/Library/Taps/test/homebrew-tap\"",
+              ...tapStagingCommands("devsy"),
+              "brew audit --formula test/tap/devsy",
+              "brew install test/tap/devsy",
+              "brew test --verbose test/tap/devsy",
+              "devsy_home=/tmp/devsy-ci-home",
+              "mkdir -p \"$devsy_home\"",
+              `test "$(DEVSY_HOME="$devsy_home" devsy --version)" = "v${build.version}"`,
+              "test -z \"$(find \"$devsy_home\" -type f -print -quit)\"",
+            ].join("\n"),
+          ])
+          .stdout()
+      }
+      case "devsy-desktop": {
+        const desktopBuild = await this.buildDevsyDesktopArtifact()
+        const cliBuild = await this.buildDevsyCliArtifacts()
+        const caskContents = await tap.file("Casks/devsy-desktop.rb").contents()
+        const formulaContents = await tap.file("Formula/devsy.rb").contents()
+        const updatedCask = this.renderDevsyDesktopCask(
+          caskContents,
+          `file:///artifacts/${desktopBuild.asset.assetName}`,
+          desktopBuild.version,
+          desktopBuild.asset.sha256,
+        )
+        const updatedFormula = this.renderDevsyFormula(formulaContents, cliBuild, {
+          amd64: `file:///artifacts/${cliBuild.amd64.assetName}`,
+          arm64: `file:///artifacts/${cliBuild.arm64.assetName}`,
+        })
+        const smokeTap = tap
+          .withFile("Casks/devsy-desktop.rb", dag.file("devsy-desktop.rb", updatedCask))
+          .withFile("Formula/devsy.rb", dag.file("devsy.rb", updatedFormula))
+
+        return dag
+          .container()
+          .from(BREW_IMAGE)
+          .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
+          .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
+          .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
+          .withDirectory("/tap", smokeTap)
+          .withFile(
+            `/artifacts/${desktopBuild.asset.assetName}`,
+            desktopBuild.container.file(desktopBuild.asset.artifactPath),
+          )
+          .withFile(
+            `/artifacts/${cliBuild.amd64.assetName}`,
+            cliBuild.container.file(cliBuild.amd64.artifactPath),
+          )
+          .withFile(
+            `/artifacts/${cliBuild.arm64.assetName}`,
+            cliBuild.container.file(cliBuild.arm64.artifactPath),
+          )
+          .withExec([
+            "bash",
+            "-lc",
+            [
+              "set -euo pipefail",
+              "repo=$(brew --repository)",
+              "tap_dir=\"$repo/Library/Taps/test/homebrew-tap\"",
+              ...tapStagingCommands("devsy-desktop"),
+              "brew audit --formula test/tap/devsy",
+              "brew audit --cask test/tap/devsy-desktop",
+              "brew install test/tap/devsy",
+              "brew install --cask test/tap/devsy-desktop",
+              `test "$(devsy --version)" = "v${desktopBuild.version}"`,
+              `test "$(readlink -f "$(brew --prefix)/bin/devsy")" = "$(brew --cellar)/devsy/${desktopBuild.version}/bin/devsy"`,
+              "test -x \"$(brew --prefix)/bin/devsy-desktop\"",
+              "! grep -q -- '--no-sandbox' \"$(brew --prefix)/bin/devsy-desktop\"",
+              "test -f \"$HOME/.local/share/applications/devsy-desktop.desktop\"",
+              "grep -q 'Exec=.*/bin/devsy-desktop %U' \"$HOME/.local/share/applications/devsy-desktop.desktop\"",
+              "grep -q 'x-scheme-handler/devsy' \"$HOME/.local/share/applications/devsy-desktop.desktop\"",
+              "test -f \"$HOME/.local/share/icons/hicolor/128x128/apps/devsy-desktop.png\"",
+              "embedded_cli=$(find \"$(brew --prefix)/Caskroom/devsy-desktop\" -path '*/squashfs-root/resources/bin/devsy' -type f -print -quit)",
+              "test -n \"$embedded_cli\"",
+              `test "$(sha256sum "$embedded_cli" | awk '{print $1}')" = "${cliBuild.amd64.sha256}"`,
+              "test -n \"$(find \"$(brew --prefix)/Caskroom/devsy-desktop\" -path '*/squashfs-root/usr/lib/libappindicator.so.1' -type f -print -quit)\"",
+              "test -n \"$(find \"$(brew --prefix)/Caskroom/devsy-desktop\" -name 'Devsy_linux_x86_64.AppImage' -type f -perm -111 -print -quit)\"",
             ].join("\n"),
           ])
           .stdout()
@@ -3332,6 +3631,14 @@ end
         const build = await this.buildDevpodArtifact()
         return json(this.devpodReleaseMetadata(build))
       }
+      case "devsy": {
+        const build = await this.buildDevsyCliArtifacts()
+        return json(this.devsyCliReleaseMetadata(build))
+      }
+      case "devsy-desktop": {
+        const build = await this.buildDevsyDesktopArtifact()
+        return json(this.devsyDesktopReleaseMetadata(build))
+      }
       case "t3code-cli-main": {
         const build = await this.buildT3Artifact(tap, "main")
         const sha256 = (
@@ -3491,6 +3798,41 @@ end
         return dag.directory()
           .withFile(`artifacts/${build.asset.assetName}`, build.container.file(build.asset.artifactPath))
           .withFile("homebrew/devpod-linux.rb", dag.file("devpod-linux.rb", updatedCask))
+          .withFile("release.json", dag.file("release.json", json(release)))
+          .withFile("ci.log", dag.file("ci.log", ciLog))
+      }
+      case "devsy": {
+        const build = await this.buildDevsyCliArtifacts()
+        const releaseTag = `devsy-${build.version}`
+        const formulaContents = await tap.file("Formula/devsy.rb").contents()
+        const updatedFormula = this.renderDevsyFormula(formulaContents, build, {
+          amd64: `https://github.com/${TAP_REPOSITORY}/releases/download/${releaseTag}/${build.amd64.assetName}`,
+          arm64: `https://github.com/${TAP_REPOSITORY}/releases/download/${releaseTag}/${build.arm64.assetName}`,
+        })
+        const release = this.devsyCliReleaseMetadata(build)
+
+        return dag.directory()
+          .withFile(`artifacts/${build.amd64.assetName}`, build.container.file(build.amd64.artifactPath))
+          .withFile(`artifacts/${build.arm64.assetName}`, build.container.file(build.arm64.artifactPath))
+          .withFile("homebrew/devsy.rb", dag.file("devsy.rb", updatedFormula))
+          .withFile("release.json", dag.file("release.json", json(release)))
+          .withFile("ci.log", dag.file("ci.log", ciLog))
+      }
+      case "devsy-desktop": {
+        const build = await this.buildDevsyDesktopArtifact()
+        const releaseTag = `devsy-desktop-${build.version}`
+        const caskContents = await tap.file("Casks/devsy-desktop.rb").contents()
+        const updatedCask = this.renderDevsyDesktopCask(
+          caskContents,
+          `https://github.com/${TAP_REPOSITORY}/releases/download/${releaseTag}/${build.asset.assetName}`,
+          build.version,
+          build.asset.sha256,
+        )
+        const release = this.devsyDesktopReleaseMetadata(build)
+
+        return dag.directory()
+          .withFile(`artifacts/${build.asset.assetName}`, build.container.file(build.asset.artifactPath))
+          .withFile("homebrew/devsy-desktop.rb", dag.file("devsy-desktop.rb", updatedCask))
           .withFile("release.json", dag.file("release.json", json(release)))
           .withFile("ci.log", dag.file("ci.log", ciLog))
       }

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -97,6 +97,36 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     },
   },
   {
+    id: "devsy",
+    kind: "http_binary_formula",
+    homebrewPath: "Formula/devsy.rb",
+    supportsPrCi: true,
+    autoUpdate: {
+      kind: "github_release_latest_tag",
+      stripPrefix: "v",
+    },
+    upstream: {
+      kind: "github_release",
+      repo: "https://github.com/devsy-org/devsy",
+      assetPrefix: "devsy-linux-",
+    },
+  },
+  {
+    id: "devsy-desktop",
+    kind: "github_release_appimage_cask",
+    homebrewPath: "Casks/devsy-desktop.rb",
+    supportsPrCi: true,
+    autoUpdate: {
+      kind: "github_release_latest_tag",
+      stripPrefix: "v",
+    },
+    upstream: {
+      kind: "github_release",
+      repo: "https://github.com/devsy-org/devsy",
+      assetName: "Devsy_linux_x86_64.AppImage",
+    },
+  },
+  {
     id: "fizzy-cli-master",
     kind: "source_build_go_formula",
     homebrewPath: "Formula/fizzy-cli-master.rb",
@@ -274,6 +304,8 @@ const CHANGED_PATHS: Array<[string, string[]]> = [
     ["Formula/codex-release.rb", "scripts/package-codex-release.mjs"],
   ],
   ["antigravity-cli", ["Formula/antigravity-cli.rb"]],
+  ["devsy", ["Formula/devsy.rb"]],
+  ["devsy-desktop", ["Casks/devsy-desktop.rb"]],
   [
     "fizzy-cli-master",
     ["Formula/fizzy-cli-master.rb", "scripts/package-fizzy-cli-master.mjs", "dagger/fizzy-cli-master-smoke/"],

--- a/dagger/tap-pipeline/src/types.ts
+++ b/dagger/tap-pipeline/src/types.ts
@@ -18,6 +18,7 @@ export type AutoUpdateSlotId =
   | "vscode-insiders-2h"
   | "t3-daily"
   | "t3-code-6h"
+  | "devsy-daily"
   | "fizzy-daily"
 
 export type UpstreamSource =

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -25,6 +25,7 @@ test("package registry covers every planned adapter kind", () => {
   assert.deepEqual(
     [...kinds].sort(),
     [
+      "github_release_appimage_cask",
       "github_release_binary_cask",
       "github_release_deb_cask",
       "http_binary_formula",
@@ -92,6 +93,8 @@ test("auto-update slots cover the expected package set", () => {
     [
       "action-server",
       "devpod-linux",
+      "devsy",
+      "devsy-desktop",
       "fizzy-cli-master",
       "fizzy-popper-self-hosted",
       "fizzy-symphony",
@@ -273,6 +276,81 @@ test("antigravity CLI is a manual closed-source binary formula", () => {
   assert.match(formula, /class AntigravityCli < Formula/)
   assert.match(formula, /bin\/"agy"/)
   assert.match(formula, /license :cannot_represent/)
+})
+
+test("Devsy packages pin stable release assets and keep CLI and Desktop identities separate", () => {
+  const cliEntry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "devsy")
+  const desktopEntry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "devsy-desktop")
+
+  assert.ok(cliEntry)
+  assert.equal(cliEntry.kind, "http_binary_formula")
+  assert.equal(cliEntry.homebrewPath, "Formula/devsy.rb")
+  assert.equal(cliEntry.supportsPrCi, true)
+  assert.equal(cliEntry.autoUpdate.kind, "github_release_latest_tag")
+  assert.equal(cliEntry.upstream.kind, "github_release")
+
+  assert.ok(desktopEntry)
+  assert.equal(desktopEntry.kind, "github_release_appimage_cask")
+  assert.equal(desktopEntry.homebrewPath, "Casks/devsy-desktop.rb")
+  assert.equal(desktopEntry.supportsPrCi, true)
+  assert.equal(desktopEntry.autoUpdate.kind, "github_release_latest_tag")
+  assert.equal(desktopEntry.upstream.kind, "github_release")
+
+  const formula = readFileSync(new URL("../../../Formula/devsy.rb", import.meta.url), "utf8")
+  const cask = readFileSync(new URL("../../../Casks/devsy-desktop.rb", import.meta.url), "utf8")
+  const pipeline = readFileSync(new URL("../../../dagger/tap-pipeline/src/index.ts", import.meta.url), "utf8")
+  const renderer = readFileSync(new URL("../src/devsy-render.ts", import.meta.url), "utf8")
+  const readme = readFileSync(new URL("../../../README.md", import.meta.url), "utf8")
+  const formulaVersion = formula.match(/^\s*version "(\d+\.\d+\.\d+)"$/m)?.[1]
+  const caskVersion = cask.match(/^\s*version "(\d+\.\d+\.\d+)"$/m)?.[1]
+  const formulaUrls = [...formula.matchAll(/^\s*url "([^"]+)"$/gm)].map((match) => match[1])
+  const formulaDigests = [...formula.matchAll(/^\s*sha256 "([a-f0-9]{64})"$/gm)].map((match) => match[1])
+  const caskUrl = cask.match(/^\s*url "([^"]+)"$/m)?.[1]
+  const caskDigest = cask.match(/^\s*sha256 x86_64_linux: "([a-f0-9]{64})"$/m)?.[1]
+
+  assert.match(formula, /class Devsy < Formula/)
+  assert.match(formulaVersion ?? "", /^\d+\.\d+\.\d+$/)
+  assert.match(formula, /license "MPL-2\.0"/)
+  assert.equal(formulaUrls.length, 2)
+  assert.match(formulaUrls[0], new RegExp(`/(?:v|devsy-)${formulaVersion}/devsy-linux-amd64$`))
+  assert.match(formulaUrls[1], new RegExp(`/(?:v|devsy-)${formulaVersion}/devsy-linux-arm64$`))
+  assert.equal(formulaDigests.length, 2)
+  assert.notEqual(formulaDigests[0], formulaDigests[1])
+  assert.match(formula, /bin\.install binary => "devsy"/)
+  assert.match(formula, /ENV\["DEVSY_HOME"\] = testpath/)
+  assert.match(formula, /shell_output\("#\{bin\}\/devsy --version"\)/)
+  assert.doesNotMatch(formula, /devsy version/)
+  assert.doesNotMatch(formula, /self update/)
+
+  assert.match(cask, /cask "devsy-desktop"/)
+  assert.match(cask, /arch intel: "x86_64"/)
+  assert.match(cask, /depends_on arch: :x86_64/)
+  assert.doesNotMatch(cask, /arch arm/)
+  assert.equal(caskVersion, formulaVersion)
+  assert.match(caskUrl ?? "", new RegExp(`/(?:v|devsy-desktop-)${caskVersion}/Devsy_linux_x86_64\\.AppImage$`))
+  assert.match(caskDigest ?? "", /^[a-f0-9]{64}$/)
+  assert.match(cask, /target: "devsy-desktop"/)
+  assert.match(cask, /x-scheme-handler\/devsy/)
+  assert.doesNotMatch(cask, /target: "devsy"/)
+  assert.doesNotMatch(cask, /binary .*resources\/bin\/devsy/)
+  assert.doesNotMatch(cask, /--no-sandbox/)
+  assert.doesNotMatch(cask, /\bflatpak\b/i)
+  assert.doesNotMatch(cask, /\brpm\b/i)
+
+  assert.match(pipeline, /case "devsy"/)
+  assert.match(pipeline, /case "devsy-desktop"/)
+  assert.match(renderer, /GitHub digest mismatch for/)
+  assert.match(pipeline, /Devsy_linux_x86_64\.AppImage/)
+  assert.match(renderer, /devsy-linux-amd64/)
+  assert.match(renderer, /devsy-linux-arm64/)
+  assert.match(pipeline, /! grep -q -- '--no-sandbox'/)
+  assert.match(pipeline, /libappindicator\.so\.1/)
+
+  assert.match(readme, /flatpak install --user \.\/Devsy\.flatpak/)
+  assert.doesNotMatch(readme, /Devsy-\d+\.\d+\.\d+\.flatpak/)
+  assert.match(readme, /never auto-detects Bluefin/)
+  assert.match(readme, /intentionally unsupported on arm64/)
+  assert.match(readme, /updater alone[\s\S]*latest/)
 })
 
 test("codex desktop is not registered for tap auto-update or release publishing", () => {

--- a/dagger/tap-pipeline/tests/devsy-update.test.ts
+++ b/dagger/tap-pipeline/tests/devsy-update.test.ts
@@ -1,0 +1,169 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import { rewriteCaskUrl } from "../src/cask-render.ts"
+import {
+  DEVSY_AMD64_ASSET,
+  DEVSY_ARM64_ASSET,
+  DEVSY_DESKTOP_ASSET,
+  renderDevsyDesktopCask,
+  renderDevsyFormula,
+  resolveStableDevsyRelease,
+  verifyDevsyGithubDigest,
+} from "../src/devsy-render.ts"
+import { changedCiPackagesFromPaths, releaseMetadataForPackage } from "../src/library.ts"
+
+const applyReleaseBundle = new URL("../../../scripts/apply-release-bundle.mjs", import.meta.url)
+
+test("synthetic Devsy stable bump rewrites every updater-owned package surface", () => {
+  const currentFormula = readFileSync(new URL("../../../Formula/devsy.rb", import.meta.url), "utf8")
+  const currentCask = readFileSync(new URL("../../../Casks/devsy-desktop.rb", import.meta.url), "utf8")
+  const currentVersion = currentFormula.match(/^\s*version "(\d+\.\d+\.\d+)"$/m)?.[1]
+  const oldDigests = [
+    ...currentFormula.matchAll(/^\s*sha256 "([a-f0-9]{64})"$/gm),
+    ...currentCask.matchAll(/^\s*sha256 x86_64_linux: "([a-f0-9]{64})"$/gm),
+  ].map((match) => match[1])
+  const nextVersion = "9.8.7"
+  const nextTag = `v${nextVersion}`
+  const nextCommit = "b".repeat(40)
+  const sha = {
+    amd64: "1".repeat(64),
+    arm64: "2".repeat(64),
+    desktop: "3".repeat(64),
+  }
+  const asset = (name: string, digest: string) => ({
+    name,
+    browser_download_url: `https://github.com/devsy-org/devsy/releases/download/${nextTag}/${name}`,
+    digest: `sha256:${digest}`,
+  })
+  const resolved = resolveStableDevsyRelease({
+    draft: false,
+    prerelease: false,
+    tag_name: nextTag,
+    assets: [
+      asset(DEVSY_AMD64_ASSET, sha.amd64),
+      asset(DEVSY_ARM64_ASSET, sha.arm64),
+      asset(DEVSY_DESKTOP_ASSET, sha.desktop),
+    ],
+  })
+
+  verifyDevsyGithubDigest(resolved.amd64, sha.amd64)
+  verifyDevsyGithubDigest(resolved.arm64, sha.arm64)
+  verifyDevsyGithubDigest(resolved.desktop, sha.desktop)
+
+  const formulaTag = `devsy-${resolved.version}`
+  const desktopTag = `devsy-desktop-${resolved.version}`
+  const formula = renderDevsyFormula(currentFormula, {
+    version: resolved.version,
+    amd64Sha256: sha.amd64,
+    arm64Sha256: sha.arm64,
+    amd64Url: `https://github.com/joshyorko/homebrew-tools/releases/download/${formulaTag}/${DEVSY_AMD64_ASSET}`,
+    arm64Url: `https://github.com/joshyorko/homebrew-tools/releases/download/${formulaTag}/${DEVSY_ARM64_ASSET}`,
+  })
+  const cask = renderDevsyDesktopCask(
+    currentCask,
+    {
+      version: resolved.version,
+      sha256: sha.desktop,
+      downloadUrl: `https://github.com/joshyorko/homebrew-tools/releases/download/${desktopTag}/${DEVSY_DESKTOP_ASSET}`,
+    },
+    rewriteCaskUrl,
+  )
+  const formulaRelease = releaseMetadataForPackage("devsy", {
+    version: resolved.version,
+    releaseTag: formulaTag,
+    assetName: DEVSY_AMD64_ASSET,
+    artifactSha256: sha.amd64,
+    downloadUrl: `https://github.com/joshyorko/homebrew-tools/releases/download/${formulaTag}/${DEVSY_AMD64_ASSET}`,
+    releaseTitle: `Devsy CLI ${resolved.version}`,
+    releaseNotes: `Synthetic release ${resolved.upstreamTag} (${nextCommit})`,
+    commitMessage: `Update devsy formula to v${resolved.version}`,
+    upstream: {
+      kind: "github_release",
+      repo: "https://github.com/devsy-org/devsy",
+      assetPrefix: "devsy-linux-",
+      version: resolved.version,
+      commit: nextCommit,
+    },
+  })
+  const desktopRelease = releaseMetadataForPackage("devsy-desktop", {
+    version: resolved.version,
+    releaseTag: desktopTag,
+    assetName: DEVSY_DESKTOP_ASSET,
+    artifactSha256: sha.desktop,
+    downloadUrl: `https://github.com/joshyorko/homebrew-tools/releases/download/${desktopTag}/${DEVSY_DESKTOP_ASSET}`,
+    releaseTitle: `Devsy Desktop ${resolved.version}`,
+    releaseNotes: `Synthetic release ${resolved.upstreamTag} (${nextCommit})`,
+    commitMessage: `Update devsy-desktop cask to v${resolved.version}`,
+    upstream: {
+      kind: "github_release",
+      repo: "https://github.com/devsy-org/devsy",
+      assetName: DEVSY_DESKTOP_ASSET,
+      version: resolved.version,
+      commit: nextCommit,
+    },
+  })
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "devsy-update-test-"))
+  try {
+    const repo = join(tempRoot, "repo")
+    const formulaBundle = join(tempRoot, "formula-bundle")
+    const desktopBundle = join(tempRoot, "desktop-bundle")
+    mkdirSync(join(repo, "Formula"), { recursive: true })
+    mkdirSync(join(repo, "Casks"), { recursive: true })
+    mkdirSync(join(formulaBundle, "homebrew"), { recursive: true })
+    mkdirSync(join(desktopBundle, "homebrew"), { recursive: true })
+    writeFileSync(join(repo, "Formula", "devsy.rb"), currentFormula)
+    writeFileSync(join(repo, "Casks", "devsy-desktop.rb"), currentCask)
+    writeFileSync(join(formulaBundle, "homebrew", "devsy.rb"), formula)
+    writeFileSync(join(formulaBundle, "release.json"), `${JSON.stringify(formulaRelease)}\n`)
+    writeFileSync(join(desktopBundle, "homebrew", "devsy-desktop.rb"), cask)
+    writeFileSync(join(desktopBundle, "release.json"), `${JSON.stringify(desktopRelease)}\n`)
+
+    execFileSync(process.execPath, [applyReleaseBundle.pathname, "--bundle", formulaBundle, "--repo", repo])
+    execFileSync(process.execPath, [applyReleaseBundle.pathname, "--bundle", desktopBundle, "--repo", repo])
+
+    const appliedFormula = readFileSync(join(repo, "Formula", "devsy.rb"), "utf8")
+    const appliedCask = readFileSync(join(repo, "Casks", "devsy-desktop.rb"), "utf8")
+    assert.equal(appliedFormula, formula)
+    assert.equal(appliedCask, cask)
+    assert.deepEqual(
+      changedCiPackagesFromPaths(["Formula/devsy.rb", "Casks/devsy-desktop.rb"]),
+      ["devsy", "devsy-desktop"],
+    )
+    assert.match(appliedFormula, new RegExp(`version "${nextVersion}"`))
+    assert.match(appliedCask, new RegExp(`version "${nextVersion}"`))
+    assert.equal((formulaRelease.upstream as { commit: string }).commit, nextCommit)
+    assert.equal((desktopRelease.upstream as { commit: string }).commit, nextCommit)
+    assert.doesNotMatch(`${appliedFormula}\n${appliedCask}`, new RegExp(`version "${currentVersion}"`))
+    for (const digest of oldDigests) {
+      assert.doesNotMatch(`${appliedFormula}\n${appliedCask}`, new RegExp(digest))
+    }
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test("Devsy stable release resolution rejects prereleases, missing assets, and digest drift", () => {
+  const base = {
+    draft: false,
+    prerelease: false,
+    tag_name: "v2.0.0",
+    assets: [],
+  }
+
+  assert.throws(() => resolveStableDevsyRelease({ ...base, prerelease: true }), /stable semantic/)
+  assert.throws(() => resolveStableDevsyRelease(base), /missing devsy-linux-amd64/)
+  assert.throws(
+    () => verifyDevsyGithubDigest({
+      name: DEVSY_AMD64_ASSET,
+      browser_download_url: "https://example.invalid/devsy",
+      digest: `sha256:${"a".repeat(64)}`,
+    }, "b".repeat(64)),
+    /GitHub digest mismatch/,
+  )
+})

--- a/dagger/tap-pipeline/tests/planner.test.ts
+++ b/dagger/tap-pipeline/tests/planner.test.ts
@@ -51,6 +51,8 @@ test("every PR-enabled package has a changed-path trigger", () => {
     "t3code-cli-main": "Formula/t3code-cli-main.rb",
     "codex-release": "Formula/codex-release.rb",
     "antigravity-cli": "Formula/antigravity-cli.rb",
+    devsy: "Formula/devsy.rb",
+    "devsy-desktop": "Casks/devsy-desktop.rb",
     "fizzy-cli-master": "Formula/fizzy-cli-master.rb",
     "fizzy-popper-self-hosted": "Formula/fizzy-popper-self-hosted.rb",
     "fizzy-symphony": "Formula/fizzy-symphony.rb",


### PR DESCRIPTION
## Summary

- add `devsy` as a stable Linux CLI formula with verified amd64 and arm64 binaries
- add `devsy-desktop` as a first-class x86_64 Linux AppImage cask with desktop, icon, and `devsy://` integration
- keep the formula CLI and Desktop launcher independently owned and co-installable
- wire both packages through the tap registry, PR planner, scheduled/manual `devsy-daily` updater, Dagger CI, immutable release bundles, mirrored assets, and update workflow
- document Homebrew AppImage and upstream Flatpak as parallel explicit Desktop choices on Bluefin/Fedora bootc; the tap never invokes another package manager

## Upstream pin

- release: https://github.com/devsy-org/devsy/releases/tag/v1.6.1
- tag commit: `85f9bc29574ac093469b8bcb786c70a021918c37`
- `devsy-linux-amd64`: `9d833b914b6a57f6c5dedb898464dd2d789838bba23e7ad874eb2e6385183ee5`
- `devsy-linux-arm64`: `35bd019a5e9c394050497c39eed4ebb3f17d7356220c7714edee23354c5204bb`
- `Devsy_linux_x86_64.AppImage`: `615df0c58da5a700aa47ba461c9d9f9497b5a76cc254af694e1167a383a5fb47`

The pipeline resolves GitHub's stable `latest` release only in updater execution, verifies the exact asset URLs and GitHub-published SHA-256 digests, resolves the tag to its commit, and emits pinned release metadata.

## Verification

Passed:

- `npm test --prefix dagger/tap-pipeline` — 47/47 tests
- `dagger -m ./dagger/tap-pipeline call ci-check --package-id=devsy`
- `dagger -m ./dagger/tap-pipeline call ci-check --package-id=devsy-desktop`
- `dagger -m ./dagger/tap-pipeline call release-bundle --package-id=devsy`
- `dagger -m ./dagger/tap-pipeline call release-bundle --package-id=devsy-desktop`
- `dagger -m ./dagger/tap-pipeline call auto-update-status --slot-id=devsy-daily`
- `git diff --check`

The CLI gate audits, installs, runs `brew test`, asserts exact `v1.6.1`, and verifies the disposable `DEVSY_HOME` remains empty. The Desktop gate audits both packages, installs them together, proves the formula-owned `devsy` remains on PATH, rejects `--no-sandbox` in the installed wrapper, and verifies desktop/protocol metadata, the embedded byte-identical CLI, executable AppImage, and bundled AppIndicator.

A real Bluefin Wayland user-session validation also passed before publication: window startup, active tray/status menu, `devsy://` protocol launch, Electron sandbox intact, formula/cask coexistence, and clean exit.

The synthetic v9.8.7 test runs stable resolution, digest verification, formula/cask rendering, release metadata, simulated immutable bundles, bundle application, and PR changed-file planning. It proves a normal next release rewrites both authoritative package files without fixed current-version assertions or manual source/test edits.

Skipped:

- arm64 CLI runtime execution; architecture selection, URL, digest, and renderer contracts are covered statically
- Flatpak GUI installation; Flatpak remains an upstream-owned explicit alternative and is not installed or managed by this tap

## Initial mirror publication

`devsy-daily` currently reports both v1.6.1 packages as `needs_update: true` because the tap release tags are not published yet. The first updater run after merge will create `devsy-1.6.1` and `devsy-desktop-1.6.1`, upload the verified assets, and atomically apply the rendered mirror URLs.
