### PR TITLE
Retry transient release asset downloads

### DIFF
--- a/dagger/tap-pipeline/src/asset-download.ts
+++ b/dagger/tap-pipeline/src/asset-download.ts
@@ -1,0 +1,34 @@
+const DEFAULT_RETRY_DELAYS_MS = [1_000, 3_000, 7_000]
+
+export function renderAssetDownloadScript(retryDelaysMs = DEFAULT_RETRY_DELAYS_MS): string {
+  return [
+    "import { writeFile } from 'node:fs/promises'",
+    "const [url, path] = process.argv.slice(1)",
+    "const headers = { Accept: 'application/vnd.github+json', 'User-Agent': 'tap-pipeline' }",
+    "if (process.env.GH_TOKEN) {",
+    "  headers.Authorization = `Bearer ${process.env.GH_TOKEN}`",
+    "}",
+    `const retryDelaysMs = ${JSON.stringify(retryDelaysMs)}`,
+    "const retryableStatuses = new Set([429, 500, 502, 503, 504])",
+    "const wait = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs))",
+    "const totalAttempts = retryDelaysMs.length + 1",
+    "for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {",
+    "  try {",
+    "    const response = await fetch(url, { headers })",
+    "    if (response.ok) {",
+    "      await writeFile(path, Buffer.from(await response.arrayBuffer()))",
+    "      break",
+    "    }",
+    "    if (!retryableStatuses.has(response.status) || attempt === totalAttempts) {",
+    "      throw new Error(`Failed to download ${url}: ${response.status} after ${attempt} attempt${attempt === 1 ? '' : 's'}`)",
+    "    }",
+    "  } catch (error) {",
+    "    if (error.message.startsWith('Failed to download') || attempt === totalAttempts) {",
+    "      if (error.message.startsWith('Failed to download')) throw error",
+    "      throw new Error(`Failed to download ${url}: ${error.message} after ${attempt} attempts`, { cause: error })",
+    "    }",
+    "  }",
+    "  await wait(retryDelaysMs[attempt - 1])",
+    "}",
+  ].join("\n")
+}

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -21,6 +21,7 @@ import {
   verifyDevsyGithubDigest,
 } from "./devsy-render.js"
 import { renderGithubApiFetchScript } from "./github-api.js"
+import { renderAssetDownloadScript } from "./asset-download.js"
 
 const TAP_DIR = "/tap"
 const BREW_IMAGE = "homebrew/brew:latest"
@@ -2381,19 +2382,7 @@ end
       "node",
       "--input-type=module",
       "-e",
-      [
-        "import { writeFile } from 'node:fs/promises'",
-        "const [url, path] = process.argv.slice(1)",
-        "const headers = { Accept: 'application/vnd.github+json', 'User-Agent': 'tap-pipeline' }",
-        "if (process.env.GH_TOKEN) {",
-        "  headers.Authorization = `Bearer ${process.env.GH_TOKEN}`",
-        "}",
-        "const response = await fetch(url, { headers })",
-        "if (!response.ok) {",
-        "  throw new Error(`Failed to download ${url}: ${response.status}`)",
-        "}",
-        "await writeFile(path, Buffer.from(await response.arrayBuffer()))",
-      ].join("\n"),
+      renderAssetDownloadScript(),
       url,
       path,
     ])

--- a/dagger/tap-pipeline/tests/asset-download.test.ts
+++ b/dagger/tap-pipeline/tests/asset-download.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { createServer } from "node:http"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+import { renderAssetDownloadScript } from "../src/asset-download.ts"
+
+async function runDownloadScript(url: string, destination: string) {
+  return await new Promise<{ code: number | null; stderr: string }>((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--input-type=module", "-e", renderAssetDownloadScript([0, 0, 0]), url, destination],
+    )
+    let stderr = ""
+
+    child.stderr.setEncoding("utf8")
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk
+    })
+    child.on("error", reject)
+    child.on("close", (code) => resolve({ code, stderr }))
+  })
+}
+
+test("asset downloads retry a transient response and write the verified response body", async () => {
+  let requests = 0
+  const server = createServer((_request, response) => {
+    requests += 1
+    if (requests === 1) {
+      response.writeHead(500).end("temporary failure")
+      return
+    }
+
+    response.writeHead(200).end("release asset")
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const directory = await mkdtemp(join(tmpdir(), "tap-pipeline-download-"))
+  const destination = join(directory, "asset")
+
+  try {
+    const result = await runDownloadScript(`http://127.0.0.1:${address.port}/asset`, destination)
+
+    assert.equal(result.code, 0, result.stderr)
+    assert.equal(requests, 2)
+    assert.equal(await readFile(destination, "utf8"), "release asset")
+  } finally {
+    server.close()
+    await rm(directory, { force: true, recursive: true })
+  }
+})
+
+test("asset downloads fail immediately for permanent HTTP errors", async () => {
+  let requests = 0
+  const server = createServer((_request, response) => {
+    requests += 1
+    response.writeHead(404).end("missing")
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const directory = await mkdtemp(join(tmpdir(), "tap-pipeline-download-"))
+
+  try {
+    const result = await runDownloadScript(
+      `http://127.0.0.1:${address.port}/missing`,
+      join(directory, "asset"),
+    )
+
+    assert.equal(result.code, 1)
+    assert.equal(requests, 1)
+    assert.match(result.stderr, /Failed to download .*: 404 after 1 attempt/)
+  } finally {
+    server.close()
+    await rm(directory, { force: true, recursive: true })
+  }
+})
+
+test("asset downloads report the final transient response after exhausting retries", async () => {
+  let requests = 0
+  const server = createServer((_request, response) => {
+    requests += 1
+    response.writeHead(503).end("still unavailable")
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const directory = await mkdtemp(join(tmpdir(), "tap-pipeline-download-"))
+
+  try {
+    const result = await runDownloadScript(
+      `http://127.0.0.1:${address.port}/unavailable`,
+      join(directory, "asset"),
+    )
+
+    assert.equal(result.code, 1)
+    assert.equal(requests, 4)
+    assert.match(result.stderr, /Failed to download .*: 503 after 4 attempts/)
+  } finally {
+    server.close()
+    await rm(directory, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
## Summary

- retry release asset downloads after HTTP 429, 500, 502, 503, and 504 responses
- use bounded 1s, 3s, and 7s backoff delays while preserving immediate failure for permanent HTTP errors
- add executable regression coverage for transient recovery, permanent failure, and exhausted-retry diagnostics

## Incident

The manually dispatched Devsy auto-update failed when the `devsy-desktop` bundle received one HTTP 500 downloading the pinned `devsy-linux-amd64` release asset. The parallel `devsy` bundle downloaded the same URL successfully. Rerunning the failed jobs completed and published successfully:

https://github.com/joshyorko/homebrew-tools/actions/runs/30108577294

## Verification

- `npm test` in `dagger/tap-pipeline`
- `dagger -m ./dagger/tap-pipeline call ci-check --package-id=devsy`
- `dagger -m ./dagger/tap-pipeline call ci-check --package-id=devsy-desktop`
- `dagger -m ./dagger/tap-pipeline call -o /tmp/homebrew-tools-devsy-release-bundle release-bundle --package-id=devsy`
- `dagger -m ./dagger/tap-pipeline call -o /tmp/homebrew-tools-devsy-desktop-release-bundle release-bundle --package-id=devsy-desktop`
- `git diff origin/main --check`
