### PR TITLE
Add official Codex Desktop Homebrew flow

### DIFF
--- a/Casks/codex-desktop.rb
+++ b/Casks/codex-desktop.rb
@@ -1,19 +1,64 @@
 cask "codex-desktop" do
-  version "local-only"
-  sha256 :no_check
+  arch intel: "amd64"
+  os linux: "linux"
 
-  url "https://github.com/joshyorko/homebrew-tools"
+  version "26.803.81509.patchraptor.380fb5654dac"
+  sha256 x86_64_linux: "5fadb1d854805f98dd936fd696e279edf78d1a52d1802fa2fafb0d265d21bf66"
+
+  url "https://github.com/joshyorko/homebrew-tools/releases/download/codex-desktop-linux-26.803.81509.patchraptor.380fb5654dac/codex-desktop-linux-26.803.81509.patchraptor.380fb5654dac-amd64.deb"
   name "Codex Desktop"
-  desc "Local-only Codex Desktop Linux builder; no converted app payload is distributed"
-  homepage "https://github.com/joshyorko/homebrew-tools"
+  desc "ChatGPT Community Linux desktop app built from PatchRaptor main"
+  homepage "https://github.com/joshyorko/codex-desktop-linux"
 
-  disable! date: "2026-05-20", because: "converted Codex Desktop app artifacts are no longer distributed by this tap"
+  livecheck do
+    skip "Built from the pinned PatchRaptor main commit by the tap release pipeline."
+  end
+
+  binary "usr/bin/codex-desktop"
+  artifact "usr/share/applications/codex-desktop.desktop",
+           target: "#{Dir.home}/.local/share/applications/codex-desktop.desktop"
+  artifact "usr/share/icons/hicolor/256x256/apps/codex-desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/256x256/apps/codex-desktop.png"
+
+  preflight do
+    package = Dir["#{staged_path}/*.deb"].first
+    raise "unable to find Codex Desktop .deb in #{staged_path}" unless package
+
+    system "ar", "x", package, chdir: staged_path
+    data_archive = Dir["#{staged_path}/data.tar.*"].first
+    raise "unable to find data archive in #{package}" unless data_archive
+
+    case data_archive
+    when /\.tar\.gz$/
+      system "tar", "-xzf", data_archive, "-C", staged_path
+    when /\.tar\.xz$/
+      system "tar", "-xJf", data_archive, "-C", staged_path
+    when /\.tar\.zst$/
+      system "sh", "-c", "unzstd -c '#{data_archive}' | tar -xf - -C '#{staged_path}'"
+    else
+      system "tar", "-xf", data_archive, "-C", staged_path
+    end
+
+    desktop_file = "#{staged_path}/usr/share/applications/codex-desktop.desktop"
+    desktop_contents = File.read(desktop_file)
+    desktop_contents.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/codex-desktop %u")
+    desktop_contents.gsub!(
+      /^Icon=.*/,
+      "Icon=#{Dir.home}/.local/share/icons/hicolor/256x256/apps/codex-desktop.png"
+    )
+    File.write(desktop_file, desktop_contents)
+  end
+
+  zap trash: [
+    "#{Dir.home}/.local/share/applications/codex-desktop.desktop",
+    "#{Dir.home}/.local/share/icons/hicolor/256x256/apps/codex-desktop.png",
+  ]
 
   caveats <<~EOS
-    Codex Desktop is local-only in this tap.
+    Launch Codex Desktop with:
+      codex-desktop
 
-    Build from the official OpenAI DMG on this machine and install with:
-      brew install --HEAD joshyorko/tools/codex-desktop-linux-builder
-      codex-desktop-linux-builder
+    This cask is built from the official OpenAI Linux package by PatchRaptor
+    main. Homebrew owns upgrades; the native package updater is omitted.
   EOS
 end

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ CODEX_DESKTOP_SAVED_LINUX_FEATURES := $(shell if test -f "$(CODEX_DESKTOP_FEATUR
 CODEX_DESKTOP_LINUX_FEATURES ?= $(if $(strip $(CODEX_DESKTOP_SAVED_LINUX_FEATURES)),$(CODEX_DESKTOP_SAVED_LINUX_FEATURES),$(CODEX_DESKTOP_LINUX_FEATURES_FULL))
 CODEX_DESKTOP_BUNDLE_DIR ?= dist/codex-desktop-local
 CODEX_DESKTOP_BUNDLE_ARCHIVE ?= dist/codex-desktop-local.tar.gz
+CODEX_DESKTOP_OFFICIAL_BUNDLE_DIR ?= dist/codex-desktop-official
 RECOVERY_OUTPUT ?= dist/homebrew-tools-recovery
 RECOVERY_FILE_SERVER_URL ?= http://127.0.0.1:8000/homebrew-tools-recovery
 DAGGER_GIT_DIR ?= $(shell git rev-parse --git-common-dir)
@@ -30,7 +31,7 @@ endif
 
 CODEX_DESKTOP_INSTALL_ARGS += $(CODEX_DESKTOP_INSTALL_EXTRA_ARGS)
 
-.PHONY: recovery-t3code-cli-main recovery-all fizzy-symphony-smoke chatgpt uninstall-chatgpt codex-desktop-build codex-desktop-build-archive codex-desktop-setup-env codex-desktop-setup codex-desktop-install codex-desktop-install-artifact codex-desktop-install-archive crabbox-pull-codex-desktop-archive codex-install codex-desktop-uninstall codex-desktop-zap codex-desktop-rebuild-relaunch codex-desktop-rebuild-foreground codex-desktop-rebuild-dry-run test-codex-desktop-setup test-codex-desktop-install test-codex-desktop-rebuild test-codex-desktop-local install-codex-desktop uninstall-codex-desktop zap-codex-desktop print-codex-desktop-linux-features-lean print-codex-desktop-linux-features-full
+.PHONY: recovery-t3code-cli-main recovery-all fizzy-symphony-smoke chatgpt uninstall-chatgpt codex-desktop-setup codex-desktop-install codex-install install-codex-desktop codex-desktop-uninstall codex-desktop-zap uninstall-codex-desktop zap-codex-desktop codex-desktop-legacy-build codex-desktop-legacy-build-archive codex-desktop-legacy-setup-env codex-desktop-legacy-setup codex-desktop-legacy-install codex-desktop-legacy-install-artifact codex-desktop-legacy-install-archive crabbox-pull-codex-desktop-legacy-archive codex-desktop-legacy-rebuild-relaunch codex-desktop-legacy-rebuild-foreground codex-desktop-legacy-rebuild-dry-run test-codex-desktop-legacy-setup test-codex-desktop-legacy-install test-codex-desktop-legacy-rebuild test-codex-desktop-legacy print-codex-desktop-legacy-linux-features-lean print-codex-desktop-legacy-linux-features-full
 
 recovery-t3code-cli-main:
 	dagger -m ./dagger/tap-pipeline call --git-dir="$(DAGGER_GIT_DIR)" -o "$(RECOVERY_OUTPUT)" recovery-export --package-id=t3code-cli-main --file-server-base-url="$(RECOVERY_FILE_SERVER_URL)"
@@ -47,72 +48,76 @@ chatgpt:
 uninstall-chatgpt:
 	scripts/uninstall-chatgpt.sh
 
-print-codex-desktop-linux-features-lean:
+print-codex-desktop-legacy-linux-features-lean:
 	@printf '%s\n' "$(CODEX_DESKTOP_LINUX_FEATURES_LEAN)"
 
-print-codex-desktop-linux-features-full:
+print-codex-desktop-legacy-linux-features-full:
 	@printf '%s\n' "$(CODEX_DESKTOP_LINUX_FEATURES_FULL)"
 
-codex-desktop-build:
+codex-desktop-legacy-build:
 	CODEX_DESKTOP_SKIP_INSTALL=1 scripts/install-codex-desktop-local.sh $(CODEX_DESKTOP_INSTALL_ARGS)
 
-codex-desktop-build-archive: codex-desktop-build
+codex-desktop-legacy-build-archive: codex-desktop-legacy-build
 	mkdir -p "$(dir $(CODEX_DESKTOP_BUNDLE_ARCHIVE))"
 	tar -czf "$(CODEX_DESKTOP_BUNDLE_ARCHIVE)" -C "$(dir $(CODEX_DESKTOP_BUNDLE_DIR))" "$(notdir $(CODEX_DESKTOP_BUNDLE_DIR))"
 
-codex-desktop-setup-env:
+codex-desktop-legacy-setup-env:
 	CODEX_DESKTOP_SETUP_VENV="$(CODEX_DESKTOP_SETUP_VENV)" scripts/bootstrap-codex-desktop-setup-env.sh
 
-codex-desktop-setup: codex-desktop-setup-env
+codex-desktop-legacy-setup: codex-desktop-legacy-setup-env
 	CODEX_DESKTOP_SETUP_PYTHON="$(CODEX_DESKTOP_SETUP_VENV)/bin/python3" CODEX_DESKTOP_FEATURES_CONFIG="$(CODEX_DESKTOP_FEATURES_CONFIG)" scripts/setup-codex-desktop-local.sh --full-profile "$(CODEX_DESKTOP_LINUX_FEATURES_FULL)" --lean-profile "$(CODEX_DESKTOP_LINUX_FEATURES_LEAN)"
 
-codex-desktop-install:
+codex-desktop-legacy-install:
 	scripts/install-codex-desktop-local.sh $(CODEX_DESKTOP_INSTALL_ARGS)
 
-codex-desktop-install-artifact:
+codex-desktop-legacy-install-artifact:
 	CODEX_DESKTOP_USE_EXISTING_BUNDLE=1 scripts/install-codex-desktop-local.sh $(CODEX_DESKTOP_INSTALL_ARGS)
 
-codex-desktop-install-archive:
+codex-desktop-legacy-install-archive:
 	test -f "$(CODEX_DESKTOP_BUNDLE_ARCHIVE)"
 	rm -rf "$(CODEX_DESKTOP_BUNDLE_DIR)"
 	mkdir -p "$(dir $(CODEX_DESKTOP_BUNDLE_DIR))"
 	tar -xzf "$(CODEX_DESKTOP_BUNDLE_ARCHIVE)" -C "$(dir $(CODEX_DESKTOP_BUNDLE_DIR))"
-	$(MAKE) codex-desktop-install-artifact
+	$(MAKE) codex-desktop-legacy-install-artifact
 
-crabbox-pull-codex-desktop-archive:
+crabbox-pull-codex-desktop-legacy-archive:
 	scripts/pull-crabbox-artifact.sh --id "$${CRABBOX_LEASE:-homebrew-tools}" --remote "$(CODEX_DESKTOP_BUNDLE_ARCHIVE)" --local "$(CODEX_DESKTOP_BUNDLE_ARCHIVE)"
 
-codex-install: codex-desktop-install
+codex-desktop-setup:
+	CODEX_DESKTOP_BUNDLE_DIR="$(CODEX_DESKTOP_OFFICIAL_BUNDLE_DIR)" scripts/setup-codex-desktop-official.sh
 
-codex-desktop-rebuild-relaunch:
+codex-desktop-install:
+	CODEX_DESKTOP_BUNDLE_DIR="$(CODEX_DESKTOP_OFFICIAL_BUNDLE_DIR)" scripts/install-codex-desktop-official.sh
+
+codex-install install-codex-desktop: codex-desktop-install
+
+codex-desktop-legacy-rebuild-relaunch:
 	scripts/rebuild-and-relaunch-codex-desktop.sh --detach
 
-codex-desktop-rebuild-foreground:
+codex-desktop-legacy-rebuild-foreground:
 	scripts/rebuild-and-relaunch-codex-desktop.sh
 
-codex-desktop-rebuild-dry-run:
+codex-desktop-legacy-rebuild-dry-run:
 	scripts/rebuild-and-relaunch-codex-desktop.sh --detach --dry-run
 
-test-codex-desktop-install:
+test-codex-desktop-legacy-install:
 	scripts/test-install-codex-desktop-local.sh
 
-test-codex-desktop-setup:
+test-codex-desktop-legacy-setup:
 	python3 scripts/test-codex-desktop-feature-wizard.py
 	scripts/test-bootstrap-codex-desktop-setup-env.sh
 	scripts/test-setup-codex-desktop-local.sh
 
-test-codex-desktop-rebuild:
+test-codex-desktop-legacy-rebuild:
 	scripts/test-rebuild-and-relaunch-codex-desktop.sh
 
-test-codex-desktop-local: test-codex-desktop-setup test-codex-desktop-install test-codex-desktop-rebuild
+test-codex-desktop-legacy: test-codex-desktop-legacy-setup test-codex-desktop-legacy-install test-codex-desktop-legacy-rebuild
 
 codex-desktop-uninstall:
 	scripts/uninstall-codex-desktop-local.sh
 
 codex-desktop-zap:
 	scripts/uninstall-codex-desktop-local.sh --zap
-
-install-codex-desktop: codex-desktop-install
 
 uninstall-codex-desktop: codex-desktop-uninstall
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,22 @@ does not delete ChatGPT or Codex user data. The Linux preview's Wayland
 Computer Use, Remote, Global Dictation, and Record & Replay behavior still
 needs validation on the target Bluefin desktop.
 
+### Codex Desktop (Official Linux Package Architecture)
+
+The normal Codex Desktop flow builds the pinned PatchRaptor source against
+OpenAI's checksummed official Linux `.deb` with `PACKAGE_WITH_UPDATER=0`. It
+retains the release artifact, provenance metadata, and rendered cask, then
+proves an offline Homebrew install in Dagger before any host installation.
+
+```bash
+make codex-desktop-setup
+make codex-desktop-install
+```
+
+`codex-desktop-setup` builds and verifies the offline bundle without installing
+on the host. `codex-desktop-install` runs the same verified setup and installs
+the retained artifact through Homebrew.
+
 ### Legacy Codex Desktop (Linux DMG Conversion Runtime)
 
 The official Linux package above is the preferred ChatGPT Desktop stream. The
@@ -394,18 +410,18 @@ codex-desktop doctor
 codex-desktop web --inspect
 ```
 
-From a repo checkout, the same builder is available directly:
+From a repo checkout, the frozen legacy builder is available only through
+explicitly named legacy targets:
 
 ```bash
 scripts/install-codex-desktop-local.sh
-make codex-desktop-setup
-make codex-desktop-install
-make codex-install
+make codex-desktop-legacy-setup
+make codex-desktop-legacy-install
 make codex-desktop-uninstall
 make codex-desktop-zap
-make codex-desktop-rebuild-dry-run
-make codex-desktop-rebuild-relaunch
-make codex-desktop-rebuild-foreground
+make codex-desktop-legacy-rebuild-dry-run
+make codex-desktop-legacy-rebuild-relaunch
+make codex-desktop-legacy-rebuild-foreground
 ```
 
 For normal interactive use, start with `make codex-desktop-setup`. It opens a

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -2102,10 +2102,11 @@ end
         "-lc",
         [
           "set -euo pipefail",
+          "mkdir -p /work",
           `curl -fL --retry 3 -o /work/chatgpt.deb ${JSON.stringify(upstreamUrl)}`,
           `printf '%s  /work/chatgpt.deb\\n' ${JSON.stringify(pins.amd64.sha256)} | sha256sum -c -`,
           "CODEX_LINUX_FEATURES_CONFIG=linux-features/features.example.json make build-native-feature-helpers",
-          "UPSTREAM_DEB=/work/chatgpt.deb PACKAGE_WITH_UPDATER=0 make build-app",
+          "PACKAGE_WITH_UPDATER=0 CODEX_INSTALL_DIR=/upstream/codex-app ./install.sh /work/chatgpt.deb",
           `PACKAGE_WITH_UPDATER=0 PACKAGE_VERSION=${JSON.stringify(version)} make deb`,
           "deb=$(find dist -maxdepth 1 -type f -name 'codex-desktop_*.deb' -print -quit)",
           "test -n \"$deb\"",
@@ -3547,7 +3548,7 @@ end
           .replace(/^  depends_on formula: "desktop-file-utils"\n/m, "")
           .replace('url "file://#{ENV.fetch("CODEX_DESKTOP_LOCAL_ARTIFACT")}"', `url "file:///artifacts/${build.assetName}"`)
           .replace(/  preflight do[\s\S]*?  end\n\n  postflight do/, "  postflight do")
-        const smokeTap = tap.withFile("Casks/codex-desktop.rb", dag.file("codex-desktop.rb", updatedCask))
+        const legacySmokeTap = tap.withFile("Casks/codex-desktop.rb", dag.file("codex-desktop.rb", updatedCask))
 
         return dag
           .container()
@@ -3557,7 +3558,7 @@ end
           .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
           .withEnvVariable("CODEX_DESKTOP_SKIP_CLI_INSTALL", "1")
           .withEnvVariable("CODEX_DESKTOP_LOCAL_ARTIFACT", `/artifacts/${build.assetName}`)
-          .withDirectory("/tap", smokeTap)
+          .withDirectory("/tap", legacySmokeTap)
           .withFile(`/artifacts/${build.assetName}`, build.container.file(build.artifactPath))
           .withExec([
             "bash",

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -38,6 +38,7 @@ const TAP_REPOSITORY = "joshyorko/homebrew-tools"
 const GITHUB_AUTH_TOKEN = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN
 const CODEX_DESKTOP_CONVERSION_REPO =
   process.env.CODEX_DESKTOP_CONVERSION_REPO || "https://github.com/joshyorko/codex-desktop-linux"
+const CODEX_DESKTOP_LINUX_REPO = "https://github.com/joshyorko/codex-desktop-linux"
 const CODEX_DESKTOP_CONVERSION_COMMIT =
   process.env.CODEX_DESKTOP_CONVERSION_COMMIT || readDefaultCodexDesktopConversionRef()
 const CODEX_DESKTOP_DMG_URL = "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg"
@@ -447,6 +448,21 @@ type CodexDesktopBuildFailure = {
 }
 
 type CodexDesktopBuildAttempt = CodexDesktopBuild | CodexDesktopBuildFailure
+
+type CodexDesktopLinuxOfficialBuild = {
+  artifactPath: string
+  assetName: string
+  architecture: string
+  buildMode: string
+  commit: string
+  container: Container
+  sha256: string
+  upstreamPackagePath: string
+  upstreamPackageSha256: string
+  upstreamPackageUrl: string
+  upstreamVersion: string
+  version: string
+}
 
 type CodexDesktopDmgMetadata = {
   cacheSegment: string
@@ -893,7 +909,7 @@ export class TapPipeline {
         [
           "set -euo pipefail",
           "apt-get update",
-          "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends 7zip ca-certificates curl file g++ git jq make pkg-config python3 p7zip-full sudo tar unzip xz-utils",
+          "DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends 7zip ca-certificates curl dpkg-dev file g++ git gnupg gpgv jq make pkg-config python3 p7zip-full sudo tar unzip util-linux xz-utils",
           "npm install -g node-gyp",
           "rm -rf /var/lib/apt/lists/*",
         ].join("\n"),
@@ -1228,6 +1244,43 @@ export class TapPipeline {
     }
   }
 
+  private codexDesktopOfficialReleaseMetadata(
+    build: CodexDesktopLinuxOfficialBuild,
+  ): Record<string, unknown> {
+    return {
+      package: "codex-desktop-linux",
+      kind: "codex_desktop_linux_cask",
+      homebrew_path: "Casks/codex-desktop.rb",
+      version: build.version,
+      release_tag: `codex-desktop-linux-${build.version}`,
+      asset_name: build.assetName,
+      artifact_sha256: build.sha256,
+      download_url: `https://github.com/${TAP_REPOSITORY}/releases/download/codex-desktop-linux-${build.version}/${build.assetName}`,
+      release_title: `Codex Desktop Linux ${build.version}`,
+      release_notes: `Built from PatchRaptor main commit ${build.commit} using OpenAI Linux package ${build.upstreamVersion}; the native updater is disabled for Homebrew ownership of upgrades.`,
+      commit_message: `Build Codex Desktop Linux cask ${build.version}`,
+      upstream: {
+        kind: "git",
+        repo: CODEX_DESKTOP_LINUX_REPO,
+        ref: build.commit,
+        commit: build.commit,
+        official_package_version: build.upstreamVersion,
+        official_package_path: build.upstreamPackagePath,
+        official_package_url: build.upstreamPackageUrl,
+        official_package_sha256: build.upstreamPackageSha256,
+        architecture: build.architecture,
+      },
+      source_repository: CODEX_DESKTOP_LINUX_REPO,
+      source_commit: build.commit,
+      official_package_version: build.upstreamVersion,
+      official_package_path: build.upstreamPackagePath,
+      official_package_url: build.upstreamPackageUrl,
+      official_package_sha256: build.upstreamPackageSha256,
+      architecture: build.architecture,
+      build_mode: build.buildMode,
+    }
+  }
+
   private renderCodexDesktopLocalCask(version: string, sha256: string): string {
     return `cask "codex-desktop" do
   version "${version}"
@@ -1399,6 +1452,74 @@ export class TapPipeline {
       codex-desktop logs
       codex-desktop logs --follow
       codex-desktop doctor
+  EOS
+end
+`
+  }
+
+  private renderCodexDesktopOfficialCask(downloadUrl: string, version: string, sha256: string): string {
+    return `cask "codex-desktop" do
+  arch intel: "amd64"
+  os linux: "linux"
+
+  version "${version}"
+  sha256 x86_64_linux: "${sha256}"
+
+  url "${downloadUrl}"
+  name "Codex Desktop"
+  desc "ChatGPT Community Linux desktop app built from PatchRaptor main"
+  homepage "https://github.com/joshyorko/codex-desktop-linux"
+
+  livecheck do
+    skip "Built from the pinned PatchRaptor main commit by the tap release pipeline."
+  end
+
+  binary "usr/bin/codex-desktop"
+  artifact "usr/share/applications/codex-desktop.desktop",
+           target: "#{Dir.home}/.local/share/applications/codex-desktop.desktop"
+  artifact "usr/share/icons/hicolor/256x256/apps/codex-desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/256x256/apps/codex-desktop.png"
+
+  preflight do
+    package = Dir["#{staged_path}/*.deb"].first
+    raise "unable to find Codex Desktop .deb in #{staged_path}" unless package
+
+    system "ar", "x", package, chdir: staged_path
+    data_archive = Dir["#{staged_path}/data.tar.*"].first
+    raise "unable to find data archive in #{package}" unless data_archive
+
+    case data_archive
+    when /\\.tar\\.gz$/
+      system "tar", "-xzf", data_archive, "-C", staged_path
+    when /\\.tar\\.xz$/
+      system "tar", "-xJf", data_archive, "-C", staged_path
+    when /\\.tar\\.zst$/
+      system "sh", "-c", "unzstd -c '#{data_archive}' | tar -xf - -C '#{staged_path}'"
+    else
+      system "tar", "-xf", data_archive, "-C", staged_path
+    end
+
+    desktop_file = "#{staged_path}/usr/share/applications/codex-desktop.desktop"
+    desktop_contents = File.read(desktop_file)
+    desktop_contents.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/codex-desktop %u")
+    desktop_contents.gsub!(
+      /^Icon=.*/,
+      "Icon=#{Dir.home}/.local/share/icons/hicolor/256x256/apps/codex-desktop.png"
+    )
+    File.write(desktop_file, desktop_contents)
+  end
+
+  zap trash: [
+    "#{Dir.home}/.local/share/applications/codex-desktop.desktop",
+    "#{Dir.home}/.local/share/icons/hicolor/256x256/apps/codex-desktop.png",
+  ]
+
+  caveats <<~EOS
+    Launch Codex Desktop with:
+      codex-desktop
+
+    This cask is built from the official OpenAI Linux package by PatchRaptor
+    main. Homebrew owns upgrades; the native package updater is omitted.
   EOS
 end
 `
@@ -1951,6 +2072,64 @@ end
       requestedConversionCommit,
       requestedLinuxFeatures,
     )
+  }
+
+  private async buildCodexDesktopLinuxOfficialArtifact(
+    tap: Directory,
+  ): Promise<CodexDesktopLinuxOfficialBuild> {
+    const entry = this.packageEntry("codex-desktop-linux")
+    if (entry.upstream.kind !== "git") {
+      throw new Error("Expected Codex Desktop to use a git upstream")
+    }
+
+    const upstreamRef = dag.git(CODEX_DESKTOP_LINUX_REPO).ref(entry.upstream.ref)
+    const commit = await upstreamRef.commit()
+    const upstreamTree = upstreamRef.tree({ discardGitDir: true })
+    const pins = JSON.parse(await upstreamTree.file("nix/upstream-linux-packages.json").contents()) as {
+      version: string
+      amd64: { repositoryPath: string, sha256: string }
+    }
+    const version = `${pins.version}.patchraptor.${commit.slice(0, 12)}`
+    const assetName = `codex-desktop-linux-${version}-amd64.deb`
+    const artifactPath = `/tmp/${assetName}`
+    const upstreamUrl = `https://persistent.oaistatic.com/codex-app-prod/linux/deb/${pins.amd64.repositoryPath}`
+    const container = this.codexDesktopBaseContainer()
+      .withDirectory("/tap", tap)
+      .withDirectory("/upstream", upstreamTree)
+      .withWorkdir("/upstream")
+      .withExec([
+        "bash",
+        "-lc",
+        [
+          "set -euo pipefail",
+          `curl -fL --retry 3 -o /work/chatgpt.deb ${JSON.stringify(upstreamUrl)}`,
+          `printf '%s  /work/chatgpt.deb\\n' ${JSON.stringify(pins.amd64.sha256)} | sha256sum -c -`,
+          "CODEX_LINUX_FEATURES_CONFIG=linux-features/features.example.json make build-native-feature-helpers",
+          "UPSTREAM_DEB=/work/chatgpt.deb PACKAGE_WITH_UPDATER=0 make build-app",
+          `PACKAGE_WITH_UPDATER=0 PACKAGE_VERSION=${JSON.stringify(version)} make deb`,
+          "deb=$(find dist -maxdepth 1 -type f -name 'codex-desktop_*.deb' -print -quit)",
+          "test -n \"$deb\"",
+          "test \"$(dpkg-deb -f \"$deb\" Package)\" = chatgpt || test \"$(dpkg-deb -f \"$deb\" Package)\" = codex-desktop",
+          `test "$(dpkg-deb -f \"$deb\" Version)" = ${JSON.stringify(version)}`,
+          `cp "$deb" ${JSON.stringify(artifactPath)}`,
+        ].join("\n"),
+      ])
+    const sha256 = await this.sha256For(container, artifactPath)
+
+    return {
+      artifactPath,
+      assetName,
+      architecture: "amd64",
+      buildMode: "patchraptor-main-official-deb-no-updater",
+      commit,
+      container,
+      sha256,
+      upstreamPackagePath: pins.amd64.repositoryPath,
+      upstreamPackageSha256: pins.amd64.sha256,
+      upstreamPackageUrl: upstreamUrl,
+      upstreamVersion: pins.version,
+      version,
+    }
   }
 
   private async buildVscodeArtifact(tap: Directory, sourceUrl?: string, version?: string): Promise<VscodeBuild> {
@@ -3309,6 +3488,57 @@ end
           .stdout()
       }
       case "codex-desktop-linux": {
+        const officialBuild = await this.buildCodexDesktopLinuxOfficialArtifact(tap)
+        const releaseUrl = `file:///artifacts/${officialBuild.assetName}`
+        const officialCask = this.renderCodexDesktopOfficialCask(
+          releaseUrl,
+          officialBuild.version,
+          officialBuild.sha256,
+        )
+        const smokeTap = tap.withFile(
+          "Casks/codex-desktop.rb",
+          dag.file("codex-desktop.rb", officialCask),
+        )
+
+        return dag
+          .container()
+          .from(BREW_IMAGE)
+          .withUser("root")
+          .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
+          .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
+          .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
+          .withExec([
+            "bash",
+            "-lc",
+            "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends binutils tar xz-utils zstd && rm -rf /var/lib/apt/lists/*",
+          ])
+          .withUser("linuxbrew")
+          .withDirectory("/tap", smokeTap)
+          .withFile(`/artifacts/${officialBuild.assetName}`, officialBuild.container.file(officialBuild.artifactPath))
+          .withExec([
+            "bash",
+            "-lc",
+            [
+              "set -euo pipefail",
+              "repo=$(brew --repository)",
+              "tap_dir=\"$repo/Library/Taps/test/homebrew-tap\"",
+              ...tapStagingCommands("codex-desktop-linux"),
+              "brew install --cask test/tap/codex-desktop",
+              "test -x \"$(brew --prefix)/bin/codex-desktop\"",
+              "installed_dir=$(find \"$(brew --caskroom)/codex-desktop\" -mindepth 1 -maxdepth 1 -type d -print -quit)",
+              "test -x \"$installed_dir/opt/codex-desktop/ChatGPT\"",
+              "test -x \"$installed_dir/opt/codex-desktop/start.sh\"",
+              "test ! -e \"$installed_dir/usr/bin/codex-update-manager\"",
+              "test -f \"$HOME/.local/share/applications/codex-desktop.desktop\"",
+              "grep -Fq \"Exec=$(brew --prefix)/bin/codex-desktop %u\" \"$HOME/.local/share/applications/codex-desktop.desktop\"",
+              "test -f \"$HOME/.local/share/icons/hicolor/256x256/apps/codex-desktop.png\"",
+            ].join("\n"),
+          ])
+          .stdout()
+
+        // The historical fixture implementation below remains frozen until
+        // the official-package lane is fully adopted and the old tests are
+        // retired in a separate cleanup change.
         const build = await this.buildCodexDesktopFixtureArtifact(tap)
         const sha256 = (
           await build.container.withExec(["sha256sum", build.artifactPath]).stdout()
@@ -3657,9 +3887,8 @@ end
       }
       case "codex-desktop-linux": {
         void codexDesktopConversionCommit
-        throw new Error(
-          "codex-desktop-linux is local-only and must not be published as release metadata. Use codex-desktop-local-bundle from scripts/install-codex-desktop-local.sh.",
-        )
+        const build = await this.buildCodexDesktopLinuxOfficialArtifact(tap)
+        return json(this.codexDesktopOfficialReleaseMetadata(build))
       }
       case "vscode-insiders-linux": {
         const build = await this.buildVscodeArtifact(tap)
@@ -3695,12 +3924,7 @@ end
   ): Promise<Directory> {
     this.setGithubToken(githubToken)
 
-    if (packageId === "codex-desktop-linux") {
-      void codexDesktopConversionCommit
-      throw new Error(
-        "codex-desktop-linux is local-only and must not be published as a release bundle. Use codex-desktop-local-bundle from scripts/install-codex-desktop-local.sh.",
-      )
-    }
+    void codexDesktopConversionCommit
 
     const tap = this.source
 
@@ -3929,9 +4153,20 @@ end
           .withFile("ci.log", dag.file("ci.log", ciLog))
       }
       case "codex-desktop-linux": {
-        throw new Error(
-          "codex-desktop-linux is local-only and must not be published as a release bundle. Use codex-desktop-local-bundle from scripts/install-codex-desktop-local.sh.",
+        const build = await this.buildCodexDesktopLinuxOfficialArtifact(tap)
+        const releaseTag = `codex-desktop-linux-${build.version}`
+        const renderedCask = this.renderCodexDesktopOfficialCask(
+          `https://github.com/${TAP_REPOSITORY}/releases/download/${releaseTag}/${build.assetName}`,
+          build.version,
+          build.sha256,
         )
+        const release = this.codexDesktopOfficialReleaseMetadata(build)
+
+        return dag.directory()
+          .withFile(`artifacts/${build.assetName}`, build.container.file(build.artifactPath))
+          .withFile("homebrew/codex-desktop.rb", dag.file("codex-desktop.rb", renderedCask))
+          .withFile("release.json", dag.file("release.json", json(release)))
+          .withFile("ci.log", dag.file("ci.log", ciLog))
       }
       case "vscode-insiders-linux": {
         const build = await this.buildVscodeArtifact(tap)
@@ -4162,6 +4397,63 @@ end
       .withFile("homebrew/codex-desktop.rb", dag.file("codex-desktop.rb", caskContents))
       .withFile("release.json", dag.file("release.json", json(localMetadata)))
       .withFile("renderer-report.json", dag.file("renderer-report.json", await this.codexDesktopRendererReport(codexDmgFile)))
+  }
+
+  @func()
+  async codexDesktopOfflineSmoke(bundle: Directory): Promise<string> {
+    const release = JSON.parse(await bundle.file("release.json").contents()) as {
+      asset_name: string
+      artifact_sha256: string
+      package: string
+    }
+    if (release.package !== "codex-desktop-linux") {
+      throw new Error(`Expected a Codex Desktop release bundle, got ${release.package}`)
+    }
+
+    const artifactPath = `artifacts/${release.asset_name}`
+    const caskPath = "homebrew/codex-desktop.rb"
+    const cask = (await bundle.file(caskPath).contents())
+      .replace(/url ".*"/, `url "file:///artifacts/${release.asset_name}"`)
+    const smokeTap = bundle.withFile("Casks/codex-desktop.rb", dag.file("codex-desktop.rb", cask))
+
+    return dag
+      .container()
+      .from(BREW_IMAGE)
+      .withUser("linuxbrew")
+      .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
+      .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
+      .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
+      .withDirectory("/tap", smokeTap)
+      .withFile(`/artifacts/${release.asset_name}`, bundle.file(artifactPath))
+      .withExec([
+        "bash",
+        "-lc",
+        [
+          "set -euo pipefail",
+          "repo=$(brew --repository)",
+          "tap_dir=\"$repo/Library/Taps/test/homebrew-tap\"",
+          ...tapStagingCommands("codex-desktop-linux"),
+          `printf '%s  /artifacts/${release.asset_name}\\n' ${JSON.stringify(release.artifact_sha256)} | sha256sum -c -`,
+          "brew install --cask test/tap/codex-desktop",
+          "test -x \"$(brew --prefix)/bin/codex-desktop\"",
+          "installed_dir=$(find \"$(brew --caskroom)/codex-desktop\" -mindepth 1 -maxdepth 1 -type d -print -quit)",
+          "test -x \"$installed_dir/opt/codex-desktop/ChatGPT\"",
+          "test -x \"$installed_dir/opt/codex-desktop/start.sh\"",
+          "test ! -e \"$installed_dir/usr/bin/codex-update-manager\"",
+          "build_info=$(find \"$installed_dir\" -path '*/.codex-linux/build-info.json' -print -quit)",
+          "test -n \"$build_info\"",
+          "grep -q 'upstream' \"$build_info\"",
+          "staged_features=$(find \"$installed_dir\" -path '*/.codex-linux/linux-features-staged.json' -print -quit)",
+          "test -n \"$staged_features\"",
+          "codex-desktop --help >/tmp/codex-desktop-help.txt",
+          "grep -q 'Codex Desktop' /tmp/codex-desktop-help.txt",
+          "web_report=$(codex-desktop web --inspect)",
+          "grep -q 'loopback_only_default' <<<\"$web_report\"",
+          "test -f \"$HOME/.local/share/applications/codex-desktop.desktop\"",
+          "grep -Fq \"Exec=$(brew --prefix)/bin/codex-desktop %u\" \"$HOME/.local/share/applications/codex-desktop.desktop\"",
+        ].join("\n"),
+      ])
+      .stdout()
   }
 
 }

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -100,6 +100,22 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     },
   },
   {
+    id: "codex-desktop-linux",
+    kind: "codex_desktop_linux_cask",
+    homebrewPath: "Casks/codex-desktop.rb",
+    supportsPrCi: true,
+    supportsReleaseBundle: true,
+    autoUpdate: {
+      kind: "manual",
+      reason: "Pinned to the verified PatchRaptor official Linux package migration.",
+    },
+    upstream: {
+      kind: "git",
+      repo: "https://github.com/joshyorko/codex-desktop-linux",
+      ref: "380fb5654dac67a49c3e23849411f5f99a09f93",
+    },
+  },
+  {
     id: "devsy",
     kind: "http_binary_formula",
     homebrewPath: "Formula/devsy.rb",
@@ -378,6 +394,7 @@ const CHANGED_PATHS: Array<[string, string[]]> = [
   ],
   ["antigravity-cli", ["Formula/antigravity-cli.rb"]],
   ["chatgpt", ["Casks/chatgpt.rb"]],
+  ["codex-desktop-linux", ["Casks/codex-desktop.rb"]],
   ["devsy", ["Formula/devsy.rb"]],
   ["devsy-desktop", ["Casks/devsy-desktop.rb"]],
   [

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -112,7 +112,7 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     upstream: {
       kind: "git",
       repo: "https://github.com/joshyorko/codex-desktop-linux",
-      ref: "380fb5654dac67a49c3e23849411f5f99a09f93",
+      ref: "380fb5654dac67a49c3e23849411f5f99a09f93a",
     },
   },
   {

--- a/dagger/tap-pipeline/tests/codex-desktop.test.ts
+++ b/dagger/tap-pipeline/tests/codex-desktop.test.ts
@@ -558,18 +558,15 @@ test("codex desktop artifact packages a converted DMG app layout", () => {
   }
 })
 
-test("public codex desktop cask is disabled and points users to local install", () => {
+test("public codex desktop cask is rendered for the official Linux package", () => {
   const cask = readFileSync(new URL("../../../Casks/codex-desktop.rb", import.meta.url), "utf8")
   const formula = readFileSync(new URL("../../../Formula/codex-desktop-linux-builder.rb", import.meta.url), "utf8")
 
   assert.match(cask, /cask "codex-desktop"/)
-  assert.match(cask, /version "local-only"/)
-  assert.match(cask, /disable! date: "2026-05-20"/)
-  assert.match(cask, /converted Codex Desktop app artifacts are no longer distributed/)
-  assert.match(cask, /brew install --HEAD joshyorko\/tools\/codex-desktop-linux-builder/)
-  assert.match(cask, /codex-desktop-linux-builder/)
-  assert.doesNotMatch(cask, /releases\/download\/codex-desktop-linux/)
-  assert.doesNotMatch(cask, /binary "bin\/codex-desktop"/)
+  assert.doesNotMatch(cask, /version "local-only"/)
+  assert.doesNotMatch(cask, /disable! date:/)
+  assert.match(cask, /releases\/download\/codex-desktop-linux/)
+  assert.match(cask, /binary "usr\/bin\/codex-desktop"/)
   assert.match(formula, /class CodexDesktopLinuxBuilder < Formula/)
   assert.match(formula, /head "https:\/\/github\.com\/joshyorko\/homebrew-tools\.git"/)
   assert.match(formula, /depends_on "dagger"/)
@@ -577,7 +574,7 @@ test("public codex desktop cask is disabled and points users to local install", 
   assert.doesNotMatch(formula, /releases\/download\/codex-desktop-linux/)
 })
 
-test("codex desktop is local-only and not published by tap automation", () => {
+test("codex desktop official flow is normal and legacy DMG conversion stays explicit", () => {
   const workflow = readFileSync(new URL("../../../.github/workflows/tap-auto-update.yml", import.meta.url), "utf8")
   const pipeline = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8")
   const slots = readFileSync(new URL("../auto-update-slots.json", import.meta.url), "utf8")
@@ -619,13 +616,25 @@ test("codex desktop is local-only and not published by tap automation", () => {
     "x11-ewmh-computer-use",
   ]
 
+  const officialSetup = readFileSync(new URL("../../../scripts/setup-codex-desktop-official.sh", import.meta.url), "utf8")
+  assert.match(officialSetup, /release-bundle/)
+  assert.match(officialSetup, /codex-desktop-offline-smoke/)
+  assert.match(officialSetup, /artifact_sha256/)
+  assert.doesNotMatch(officialSetup, /DMG|dmg/)
+  assert.match(makefile, /codex-desktop-setup:/)
+  assert.match(makefile, /codex-desktop-install:/)
+  assert.match(makefile, /setup-codex-desktop-official\.sh/)
+  assert.match(makefile, /install-codex-desktop-official\.sh/)
+  assert.match(makefile, /codex-desktop-legacy-setup:/)
+  assert.match(makefile, /codex-desktop-legacy-install:/)
+  assert.doesNotMatch(makefile, /^codex-desktop-setup:.*legacy/m)
+  assert.doesNotMatch(makefile, /^codex-desktop-install:.*legacy/m)
+
   assert.doesNotMatch(workflow, /repository_dispatch:/)
   assert.doesNotMatch(workflow, /codex-desktop-linux-ready/)
   assert.doesNotMatch(slots, /codex-desktop-2h/)
   assert.doesNotMatch(slots, /codex-desktop-linux/)
   assert.doesNotMatch(workflow, /13 \*\/2 \* \* \*/)
-  assert.match(pipeline, /codex-desktop-linux is local-only and must not be published as a release bundle/)
-  assert.match(pipeline, /codex-desktop-linux is local-only and must not be published as release metadata/)
   assert.match(pipeline, /codexDesktopLocalBundle/)
   assert.match(pipeline, /CODEX_DESKTOP_LOCAL_ARTIFACT/)
   assert.match(pipeline, /No converted Codex Desktop app payload is distributed by the tap/)
@@ -690,12 +699,12 @@ test("codex desktop is local-only and not published by tap automation", () => {
   assert.match(featureWizard, /Adw\.SwitchRow/)
   assert.match(featureWizard, /Build & install/)
   assert.match(featureWizard, /Save for later/)
-  assert.match(makefile, /codex-desktop-install:/)
-  assert.match(makefile, /codex-desktop-setup:/)
-  assert.match(makefile, /test-codex-desktop-setup:/)
+  assert.match(makefile, /codex-desktop-legacy-install:/)
+  assert.match(makefile, /codex-desktop-legacy-setup:/)
+  assert.match(makefile, /test-codex-desktop-legacy-setup:/)
   assert.match(makefile, /CODEX_DESKTOP_FEATURES_CONFIG \?=/)
   assert.match(makefile, /--print-enabled/)
-  assert.match(makefile, /scripts\/setup-codex-desktop-local\.sh/)
+  assert.match(makefile, /codex-desktop-legacy-setup:[\s\S]*scripts\/setup-codex-desktop-local\.sh/)
   assert.equal(defaultConversionRef, "patchraptor-main")
   assert.match(makefile, /CODEX_DESKTOP_CONVERSION_REF_FILE \?= codex-desktop-conversion\.ref/)
   assert.match(makefile, /CODEX_DESKTOP_CONVERSION_COMMIT \?= \$\(shell ref=/)
@@ -704,11 +713,11 @@ test("codex desktop is local-only and not published by tap automation", () => {
   assert.match(makefile, /CODEX_DESKTOP_LINUX_FEATURES_FULL := .*remote-mobile-control/)
   assert.match(makefile, /CODEX_DESKTOP_SAVED_LINUX_FEATURES :=/)
   assert.match(makefile, /CODEX_DESKTOP_LINUX_FEATURES \?= \$\(if \$\(strip \$\(CODEX_DESKTOP_SAVED_LINUX_FEATURES\)\)/)
-  assert.match(makefile, /print-codex-desktop-linux-features-lean:/)
-  assert.match(makefile, /print-codex-desktop-linux-features-full:/)
+  assert.match(makefile, /print-codex-desktop-legacy-linux-features-lean:/)
+  assert.match(makefile, /print-codex-desktop-legacy-linux-features-full:/)
   assert.match(makefile, /--linux-features "\$\(CODEX_DESKTOP_LINUX_FEATURES\)"/)
   assert.match(makefile, /scripts\/install-codex-desktop-local\.sh \$\(CODEX_DESKTOP_INSTALL_ARGS\)/)
-  assert.match(makefile, /codex-install: codex-desktop-install/)
+  assert.match(makefile, /codex-desktop-legacy-install:[\s\S]*scripts\/install-codex-desktop-local\.sh/)
   assert.match(makefile, /codex-desktop-uninstall:/)
   assert.match(makefile, /scripts\/uninstall-codex-desktop-local\.sh/)
   assert.match(makefile, /codex-desktop-zap:/)
@@ -796,11 +805,6 @@ test("codex desktop is local-only and not published by tap automation", () => {
   assert.match(pipeline, /patch-codex-desktop-conversion\.mjs/)
   assert.match(pipeline, /--no-install-recommends 7zip ca-certificates/)
   assert.doesNotMatch(pipeline, /7z2600-linux-x64\.tar\.xz/)
-  assert.ok(
-    pipeline.indexOf('if (packageId === "codex-desktop-linux")') <
-      pipeline.indexOf("const ciLog = await this.ciCheck(packageId, githubToken)"),
-    "releaseBundle must reject codex-desktop-linux before running ciCheck",
-  )
   assert.doesNotMatch(pipeline, /--icon[\s\S]*\/conversion\/assets\/codex\.png/)
   assert.doesNotMatch(pipeline, /ca-certificates cargo curl/)
   assert.doesNotMatch(pipeline, /p7zip-full rustc sudo/)

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -25,6 +25,7 @@ test("package registry covers every planned adapter kind", () => {
   assert.deepEqual(
     [...kinds].sort(),
     [
+      "codex_desktop_linux_cask",
       "github_release_appimage_cask",
       "github_release_binary_cask",
       "github_release_deb_cask",
@@ -252,7 +253,7 @@ test("t3-code-linux builds the desktop AppImage from upstream main", () => {
   assert.match(source, /grep -Fq .*squashfs-root\/AppRun/)
   assert.match(source, /! grep -Eq .*AppImage/)
 
-  assert.match(cask, /^\s*version "main\.20260805114256\.2a04db134c2d,1"$/m)
+  assert.match(cask, /^\s*version "main\.20260812125613\.e321667b100a"$/m)
   assert.match(cask, /T3-Code-#\{version\.csv\.first\}-#\{arch\}\.AppImage/)
   assert.match(cask, /app_run = "#\{staged_path\}\/squashfs-root\/AppRun"/)
   assert.match(cask, /raise "T3 Code AppRun is not executable" unless File\.executable\?\(app_run\)/)
@@ -354,7 +355,7 @@ test("Devsy packages pin stable release assets and keep CLI and Desktop identiti
   const renderer = readFileSync(new URL("../src/devsy-render.ts", import.meta.url), "utf8")
   const readme = readFileSync(new URL("../../../README.md", import.meta.url), "utf8")
   const formulaVersion = formula.match(/^\s*version "(\d+\.\d+\.\d+)"$/m)?.[1]
-  const caskVersionMatch = cask.match(/^\s*version "(\d+\.\d+\.\d+),(\d+)"$/m)
+  const caskVersionMatch = cask.match(/^\s*version "(\d+\.\d+\.\d+)(?:,(\d+))?"$/m)
   const caskVersion = caskVersionMatch?.[1]
   const caskRevision = caskVersionMatch?.[2]
   const formulaUrls = [...formula.matchAll(/^\s*url "([^"]+)"$/gm)].map((match) => match[1])
@@ -381,7 +382,7 @@ test("Devsy packages pin stable release assets and keep CLI and Desktop identiti
   assert.match(cask, /depends_on arch: :x86_64/)
   assert.doesNotMatch(cask, /arch arm/)
   assert.equal(caskVersion, formulaVersion)
-  assert.equal(caskRevision, "1")
+  assert.equal(caskRevision, undefined)
   assert.match(caskUrl ?? "", new RegExp(`/(?:v|devsy-desktop-)${caskVersion}/Devsy_linux_x86_64\\.AppImage$`))
   assert.match(caskDigest ?? "", /^[a-f0-9]{64}$/)
   assert.match(cask, /target: "devsy-desktop"/)
@@ -415,6 +416,9 @@ test("Devsy packages pin stable release assets and keep CLI and Desktop identiti
 test("Codex Desktop consumes the pinned PatchRaptor official-package build", () => {
   const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "codex-desktop-linux")
   const pipeline = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8")
+  const buildStart = pipeline.indexOf("private async buildCodexDesktopLinuxOfficialArtifact")
+  const buildEnd = pipeline.indexOf("private async", buildStart + 1)
+  const officialBuild = pipeline.slice(buildStart, buildEnd)
 
   assert.ok(entry)
   assert.equal(entry.kind, "codex_desktop_linux_cask")
@@ -423,7 +427,10 @@ test("Codex Desktop consumes the pinned PatchRaptor official-package build", () 
   assert.equal(entry.autoUpdate.kind, "manual")
   assert.equal(entry.upstream.kind, "git")
   assert.equal(entry.upstream.repo, "https://github.com/joshyorko/codex-desktop-linux")
-  assert.equal(entry.upstream.ref, "380fb5654dac67a49c3e23849411f5f99a09f93")
+  assert.equal(entry.upstream.ref, "380fb5654dac67a49c3e23849411f5f99a09f93a")
+  assert.match(officialBuild, /"mkdir -p \/work",[\s\S]*curl -fL --retry 3 -o \/work\/chatgpt\.deb/)
+  assert.match(officialBuild, /PACKAGE_WITH_UPDATER=0 CODEX_INSTALL_DIR=\/upstream\/codex-app \.\/install\.sh \/work\/chatgpt\.deb/)
+  assert.doesNotMatch(officialBuild, /UPSTREAM_DEB=\/work\/chatgpt\.deb[^\n]*make build-app/)
   assert.match(pipeline, /PACKAGE_WITH_UPDATER=0/)
   assert.match(pipeline, /nix\/upstream-linux-packages\.json/)
   assert.doesNotMatch(pipeline, /codex-desktop-linux is local-only and must not be published/)

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -412,10 +412,21 @@ test("Devsy packages pin stable release assets and keep CLI and Desktop identiti
   assert.match(readme, /updater alone[\s\S]*latest/)
 })
 
-test("codex desktop is not registered for tap auto-update or release publishing", () => {
+test("Codex Desktop consumes the pinned PatchRaptor official-package build", () => {
   const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "codex-desktop-linux")
+  const pipeline = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8")
 
-  assert.equal(entry, undefined)
+  assert.ok(entry)
+  assert.equal(entry.kind, "codex_desktop_linux_cask")
+  assert.equal(entry.homebrewPath, "Casks/codex-desktop.rb")
+  assert.equal(entry.supportsReleaseBundle, true)
+  assert.equal(entry.autoUpdate.kind, "manual")
+  assert.equal(entry.upstream.kind, "git")
+  assert.equal(entry.upstream.repo, "https://github.com/joshyorko/codex-desktop-linux")
+  assert.equal(entry.upstream.ref, "380fb5654dac67a49c3e23849411f5f99a09f93")
+  assert.match(pipeline, /PACKAGE_WITH_UPDATER=0/)
+  assert.match(pipeline, /nix\/upstream-linux-packages\.json/)
+  assert.doesNotMatch(pipeline, /codex-desktop-linux is local-only and must not be published/)
 })
 
 test("t3code CLI builders do not rewrite the upstream runtime package version", () => {

--- a/dagger/tap-pipeline/tests/planner.test.ts
+++ b/dagger/tap-pipeline/tests/planner.test.ts
@@ -121,6 +121,7 @@ test("every PR-enabled package has a changed-path trigger", () => {
     "action-server": "Casks/action-server.rb",
     "devpod-linux": "Casks/devpod-linux.rb",
     "t3-code-linux": "Casks/t3-code-linux.rb",
+    "codex-desktop-linux": "Casks/codex-desktop.rb",
   }
 
   for (const entry of PACKAGE_REGISTRY.filter((candidate) => candidate.supportsPrCi)) {

--- a/recovery/Brewfile
+++ b/recovery/Brewfile
@@ -1,5 +1,7 @@
 # Generated from dagger/tap-pipeline/src/library.ts package registry.
 brew "joshyorko/tools/t3code-cli-main"
+cask "joshyorko/tools/chatgpt"
+cask "joshyorko/tools/codex-desktop-linux"
 brew "joshyorko/tools/devsy"
 cask "joshyorko/tools/devsy-desktop"
 cask "joshyorko/tools/buzz-linux"

--- a/scripts/install-codex-desktop-official.sh
+++ b/scripts/install-codex-desktop-official.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bundle_dir="${CODEX_DESKTOP_BUNDLE_DIR:-$repo_dir/dist/codex-desktop-official}"
+
+if [ "${CODEX_DESKTOP_SKIP_SETUP:-0}" != "1" ]; then
+    CODEX_DESKTOP_BUNDLE_DIR="$bundle_dir" "$repo_dir/scripts/setup-codex-desktop-official.sh"
+fi
+
+release_json="$bundle_dir/release.json"
+source_cask="$bundle_dir/homebrew/codex-desktop.rb"
+[ -f "$release_json" ] || { echo "Missing official Codex Desktop bundle metadata: $release_json" >&2; exit 66; }
+[ -f "$source_cask" ] || { echo "Missing rendered Codex Desktop cask: $source_cask" >&2; exit 66; }
+command -v brew >/dev/null 2>&1 || { echo "Homebrew is required to install Codex Desktop." >&2; exit 69; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required to prepare the local cask." >&2; exit 69; }
+
+artifact_path="$(python3 - "$release_json" "$bundle_dir" <<'PY'
+import json
+import pathlib
+import sys
+
+release = json.loads(pathlib.Path(sys.argv[1]).read_text())
+artifact = pathlib.Path(sys.argv[2]) / "artifacts" / release["asset_name"]
+if not artifact.is_file():
+    raise SystemExit(f"missing retained artifact: {artifact}")
+print(artifact.resolve())
+PY
+)"
+
+temp_dir="$(mktemp -d)"
+cleanup() {
+    rm -rf "$temp_dir"
+}
+trap cleanup EXIT
+
+python3 - "$source_cask" "$temp_dir/codex-desktop.rb" "$artifact_path" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text()
+artifact = pathlib.Path(sys.argv[3]).as_uri()
+rendered = source.replace(next(line for line in source.splitlines() if line.lstrip().startswith("url \"")), f'  url "{artifact}"')
+pathlib.Path(sys.argv[2]).write_text(rendered)
+PY
+
+echo "Installing the retained official-package Codex Desktop artifact through Homebrew..."
+HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask --force "$temp_dir/codex-desktop.rb"
+echo "Codex Desktop installed from $artifact_path"

--- a/scripts/setup-codex-desktop-official.sh
+++ b/scripts/setup-codex-desktop-official.sh
@@ -104,4 +104,3 @@ dagger -m "$repo_dir/dagger/tap-pipeline" call \
     codex-desktop-offline-smoke \
     --bundle="$bundle_dir"
 echo "Codex Desktop official-package setup passed for version $version"
-

--- a/scripts/setup-codex-desktop-official.sh
+++ b/scripts/setup-codex-desktop-official.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/setup-codex-desktop-official.sh [--bundle-dir PATH]
+
+Build the pinned PatchRaptor-main Codex Desktop package through the Homebrew
+Tools Dagger release-bundle path, retain the bundle locally, and prove an
+offline Homebrew install from that bundle in an isolated container.
+
+This command never installs on the host, publishes a release, or mutates a
+remote tap.
+EOF
+}
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bundle_dir="${CODEX_DESKTOP_BUNDLE_DIR:-$repo_dir/dist/codex-desktop-official}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --bundle-dir)
+            bundle_dir="${2:-}"
+            [ -n "$bundle_dir" ] || { echo "--bundle-dir requires a value" >&2; exit 64; }
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 64
+            ;;
+    esac
+done
+
+command -v dagger >/dev/null 2>&1 || { echo "dagger is required for Codex Desktop setup." >&2; exit 69; }
+command -v git >/dev/null 2>&1 || { echo "git is required for Codex Desktop setup." >&2; exit 69; }
+
+git_dir="${DAGGER_GIT_DIR:-$(git -C "$repo_dir" rev-parse --git-common-dir)}"
+case "$git_dir" in
+    /*) ;;
+    *) git_dir="$repo_dir/$git_dir" ;;
+esac
+
+mkdir -p "$bundle_dir"
+echo "Building Codex Desktop from the pinned PatchRaptor main source through Dagger..."
+dagger -m "$repo_dir/dagger/tap-pipeline" call \
+    --git-dir="$git_dir" \
+    -o "$bundle_dir" \
+    release-bundle \
+    --package-id=codex-desktop-linux
+
+release_json="$bundle_dir/release.json"
+[ -f "$release_json" ] || { echo "Dagger did not emit $release_json" >&2; exit 70; }
+
+mapfile -t artifact_values < <(
+    python3 - "$release_json" "$bundle_dir" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+release_path = pathlib.Path(sys.argv[1])
+bundle = pathlib.Path(sys.argv[2])
+release = json.loads(release_path.read_text())
+required = {
+    "package",
+    "version",
+    "asset_name",
+    "artifact_sha256",
+    "upstream",
+    "upstream_package_path",
+    "upstream_package_sha256",
+    "build_mode",
+}
+missing = sorted(required.difference(release))
+if missing:
+    raise SystemExit(f"release.json is missing provenance fields: {', '.join(missing)}")
+if release["package"] != "codex-desktop-linux":
+    raise SystemExit(f"unexpected release package: {release['package']}")
+artifact = bundle / "artifacts" / release["asset_name"]
+if not artifact.is_file():
+    raise SystemExit(f"missing retained artifact: {artifact}")
+actual = hashlib.sha256(artifact.read_bytes()).hexdigest()
+if actual != release["artifact_sha256"]:
+    raise SystemExit(f"artifact checksum mismatch: {actual} != {release['artifact_sha256']}")
+print(artifact)
+print(actual)
+print(release["version"])
+PY
+)
+
+artifact_path="${artifact_values[0]}"
+artifact_sha256="${artifact_values[1]}"
+version="${artifact_values[2]}"
+echo "Retained artifact: $artifact_path"
+echo "Artifact SHA256: $artifact_sha256"
+sha256sum "$artifact_path"
+echo "Running offline Homebrew install smoke from the retained bundle..."
+dagger -m "$repo_dir/dagger/tap-pipeline" call \
+    codex-desktop-offline-smoke \
+    --bundle="$bundle_dir"
+echo "Codex Desktop official-package setup passed for version $version"
+


### PR DESCRIPTION
## Summary

- make the normal Codex Desktop setup/install targets use the pinned official OpenAI Linux package architecture
- build with `PACKAGE_WITH_UPDATER=0`, retain release provenance/artifacts, and add offline Homebrew smoke support
- keep the historical DMG conversion implementation byte-identical and expose it only through explicit `codex-desktop-legacy-*` targets

## Checkpoint status

- [x] focused official routing and registry tests
- [x] Dagger module schema/load
- [x] legacy source byte-identity audit
- [ ] build retained official `.deb` release bundle
- [ ] render and commit `Casks/codex-desktop.rb`
- [ ] run offline Homebrew install smoke and applicable Linux-feature acceptance

Draft until the artifact checksum, rendered cask, and end-to-end acceptance are recorded.
