### PR TITLE
Package Headroom self-hosted from source

### DIFF
--- a/.github/workflows/tap-auto-update.yml
+++ b/.github/workflows/tap-auto-update.yml
@@ -14,6 +14,7 @@ on:
   - cron: "41 0,12,18 * * *"
   - cron: "13 10 * * *"
   - cron: "0 10 * * *"
+  - cron: "31 10 * * *"
   - cron: "23 10 * * *"
   workflow_dispatch:
     inputs:
@@ -33,6 +34,7 @@ on:
         - fizzy-daily
         - buzz-daily
         - chatgpt-daily
+        - headroom-daily
         - camp-daily
 
 permissions:
@@ -90,6 +92,7 @@ jobs:
             "41 0,12,18 * * *") slot_id="t3-code-6h" ;;
             "13 10 * * *") slot_id="buzz-daily" ;;
             "0 10 * * *") slot_id="chatgpt-daily" ;;
+            "31 10 * * *") slot_id="headroom-daily" ;;
             *)
               echo "Unknown scheduled slot for Tap Auto Update: $EVENT_SCHEDULE" >&2
               exit 1

--- a/Formula/headroom-self-hosted.rb
+++ b/Formula/headroom-self-hosted.rb
@@ -1,0 +1,32 @@
+class HeadroomSelfHosted < Formula
+  desc "Self-hosted Headroom CLI and proxy from the pinned self-hosted source"
+  homepage "https://github.com/joshyorko/headroom"
+  url "https://github.com/joshyorko/homebrew-tools/releases/download/headroom-self-hosted-selfhosted.ad7eea0d310c/headroom-self-hosted-selfhosted.ad7eea0d310c.tar.gz"
+  version "selfhosted.ad7eea0d310c"
+  sha256 "5adb3bc82de6da46fe4e1572ead51ff887ec2b6b6a7d37dc8b0feab2e43bc299"
+  license "Apache-2.0"
+
+  livecheck do
+    skip "Built from an exact self-hosted source commit by the tap release pipeline."
+  end
+
+  depends_on :linux
+  depends_on "python@3.13"
+
+  def install
+    libexec.install Dir["*"]
+    python = Formula["python@3.13"].opt_bin/"python3.13"
+    system python, "-m", "venv", libexec/"venv"
+    system libexec/"venv/bin/pip", "install", "--no-index", "--find-links=#{libexec}/wheelhouse", "headroom-ai[proxy]==0.34.0"
+
+    (bin/"headroom").write <<~SH
+      #!/bin/bash
+      exec "#{libexec}/venv/bin/headroom" "$@"
+    SH
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/headroom --help")
+    assert_match "proxy", shell_output("#{bin}/headroom proxy --help")
+  end
+end

--- a/dagger/tap-pipeline/auto-update-slots.json
+++ b/dagger/tap-pipeline/auto-update-slots.json
@@ -53,5 +53,10 @@
     "id": "chatgpt-daily",
     "description": "Daily ChatGPT Linux cask packaging smoke test.",
     "packageIds": ["chatgpt"]
+  },
+  {
+    "id": "headroom-daily",
+    "description": "Daily Headroom self-hosted source build and offline Homebrew acceptance.",
+    "packageIds": ["headroom-self-hosted"]
   }
 ]

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -3121,6 +3121,7 @@ end
         return dag
           .container()
           .from(BREW_IMAGE)
+          .withUser("linuxbrew")
           .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
           .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
           .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
@@ -3465,7 +3466,7 @@ end
         return dag
           .container()
           .from(BREW_IMAGE)
-          .withUser("root")
+          .withUser("linuxbrew")
           .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
           .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
           .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -32,6 +32,7 @@ const TAP_DIR = "/tap"
 const BREW_IMAGE = "homebrew/brew:latest"
 const NODE_IMAGE = "node:24-bookworm"
 const NODE_25_IMAGE = "node:25-bookworm"
+const PYTHON_IMAGE = "python:3.13-bookworm"
 const GO_IMAGE = "golang:1.26-bookworm"
 const RUST_IMAGE = "rust:1-bookworm"
 const TAP_REPOSITORY = "joshyorko/homebrew-tools"
@@ -241,6 +242,11 @@ function tapStagingCommands(packageId: string): string[] {
         "mkdir -p \"$tap_dir/Casks\"",
         "cp /tap/Casks/codex-desktop.rb \"$tap_dir/Casks/\"",
       ]
+    case "headroom-self-hosted":
+      return [
+        "mkdir -p \"$tap_dir/Formula\"",
+        "cp /tap/Formula/headroom-self-hosted.rb \"$tap_dir/Formula/\"",
+      ]
     case "vscode-insiders-linux":
       return [
         "mkdir -p \"$tap_dir/Casks\"",
@@ -425,6 +431,17 @@ type T3CodeBuild = {
   version: string
   container: Container
   sha256: string
+}
+
+type HeadroomBuild = {
+  artifactPath: string
+  assetName: string
+  commit: string
+  container: Container
+  sha256: string
+  sourceRef: string
+  treeHash: string
+  version: string
 }
 
 type CodexDesktopBuild = {
@@ -784,6 +801,8 @@ export class TapPipeline {
         return `t3-code-linux-${version.split(",", 1)[0]}`
       case "codex-desktop-linux":
         return `codex-desktop-linux-${version}`
+      case "headroom-self-hosted":
+        return `headroom-self-hosted-${version}`
       case "vscode-insiders-linux":
         return `vscode-insiders-linux-${version.replace(/,/g, "-")}`
       case "voxtype":
@@ -2654,6 +2673,132 @@ end
     }
   }
 
+  private async buildHeadroomArtifact(): Promise<HeadroomBuild> {
+    const entry = this.packageEntry("headroom-self-hosted")
+    if (entry.upstream.kind !== "git" || entry.autoUpdate.kind !== "git_head_sha") {
+      throw new Error("Expected Headroom self-hosted to use a git-head upstream")
+    }
+
+    const sourceRef = entry.autoUpdate.ref
+    const upstreamRef = dag.git(entry.upstream.repo).ref(sourceRef)
+    const commit = await upstreamRef.commit()
+    const commitMetadata = await this.fetchJson(
+      `${githubApiRepoUrl(entry.upstream.repo)}/git/commits/${commit}`,
+    ) as { tree?: { sha?: string } }
+    const treeHash = commitMetadata.tree?.sha
+    if (!treeHash) {
+      throw new Error(`GitHub did not return a source tree hash for Headroom commit ${commit}`)
+    }
+
+    const version = `selfhosted.${commit.slice(0, 12)}`
+    const assetName = `headroom-self-hosted-${version}.tar.gz`
+    const artifactPath = `/tmp/${assetName}`
+    const rustToolchain = dag.container().from(RUST_IMAGE)
+    const buildProvenance = {
+      package: "headroom-self-hosted",
+      source_repository: entry.upstream.repo,
+      source_ref: sourceRef,
+      source_commit: commit,
+      source_tree: treeHash,
+      build_profile: "headroom-ai[proxy]",
+      python: "3.13",
+    }
+    const container = dag
+      .container()
+      .from(PYTHON_IMAGE)
+      .withDirectory("/usr/local/cargo", rustToolchain.directory("/usr/local/cargo"))
+      .withDirectory("/usr/local/rustup", rustToolchain.directory("/usr/local/rustup"))
+      .withEnvVariable("PATH", "/usr/local/cargo/bin:/usr/local/bin:/usr/bin:/bin")
+      .withDirectory("/source", upstreamRef.tree({ discardGitDir: true }))
+      .withWorkdir("/source")
+      .withExec([
+        "bash",
+        "-lc",
+        [
+          "set -euo pipefail",
+          "mkdir -p /work/package/wheelhouse",
+          "python -m pip wheel --disable-pip-version-check --no-cache-dir --wheel-dir /work/package/wheelhouse '.[proxy]'",
+          "find /work/package/wheelhouse -maxdepth 1 -type f -name 'headroom_ai-*.whl' -print -quit | grep -q .",
+          "test \"$(find /work/package/wheelhouse -maxdepth 1 -type f -name '*.whl' | wc -l)\" -gt 1",
+          `printf '%s\\n' ${JSON.stringify(JSON.stringify(buildProvenance, null, 2))} > /work/package/provenance.json`,
+          `tar -czf ${JSON.stringify(artifactPath)} -C /work/package .`,
+        ].join("\n"),
+      ])
+    const sha256 = await this.sha256For(container, artifactPath)
+
+    return { artifactPath, assetName, commit, container, sha256, sourceRef, treeHash, version }
+  }
+
+  private renderHeadroomFormula(downloadUrl: string, version: string, sha256: string): string {
+    return `class HeadroomSelfHosted < Formula
+  desc "Self-hosted Headroom CLI and proxy from the pinned self-hosted source"
+  homepage "https://github.com/joshyorko/headroom"
+  url "${downloadUrl}"
+  version "${version}"
+  sha256 "${sha256}"
+  license "Apache-2.0"
+
+  livecheck do
+    skip "Built from an exact self-hosted source commit by the tap release pipeline."
+  end
+
+  depends_on :linux
+  depends_on "python@3.13"
+
+  def install
+    libexec.install Dir["*"]
+    python = Formula["python@3.13"].opt_bin/"python3.13"
+    system python, "-m", "venv", libexec/"venv"
+    system libexec/"venv/bin/pip", "install", "--no-index", "--find-links=#{libexec}/wheelhouse", "headroom-ai[proxy]==0.34.0"
+
+    (bin/"headroom").write <<~SH
+      #!/bin/bash
+      exec "#{libexec}/venv/bin/headroom" "$@"
+    SH
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/headroom --help")
+    assert_match "proxy", shell_output("#{bin}/headroom proxy --help")
+  end
+end
+`
+  }
+
+  private headroomReleaseMetadata(build: HeadroomBuild) {
+    const releaseTag = `headroom-self-hosted-${build.version}`
+    return releaseMetadataForPackage("headroom-self-hosted", {
+      version: build.version,
+      releaseTag,
+      assetName: build.assetName,
+      artifactSha256: build.sha256,
+      downloadUrl: `https://github.com/${TAP_REPOSITORY}/releases/download/${releaseTag}/${build.assetName}`,
+      releaseTitle: `Headroom self-hosted ${build.version}`,
+      releaseNotes: `Built from joshyorko/headroom:${build.sourceRef} commit ${build.commit} with the proxy dependency profile; Homebrew installation is offline from the retained wheelhouse.`,
+      commitMessage: `Build Headroom self-hosted ${build.version}`,
+      upstream: {
+        kind: "git",
+        repo: "https://github.com/joshyorko/headroom",
+        ref: build.sourceRef,
+        version: build.version,
+        commit: build.commit,
+      },
+    })
+  }
+
+  private headroomProvenance(build: HeadroomBuild): Record<string, string> {
+    return {
+      package: "headroom-self-hosted",
+      source_repository: "https://github.com/joshyorko/headroom",
+      source_ref: build.sourceRef,
+      source_commit: build.commit,
+      source_tree: build.treeHash,
+      artifact_sha256: build.sha256,
+      build_profile: "headroom-ai[proxy]",
+      python: "3.13",
+    }
+  }
+
   private renderRccCask(build: RccBuild, releaseTag: string): string {
     return this.renderRccCaskWithUrls(build, {
       linux: `https://github.com/${TAP_REPOSITORY}/releases/download/${releaseTag}/${build.linux.assetName}`,
@@ -3308,6 +3453,41 @@ end
           ])
           .stdout()
       }
+      case "headroom-self-hosted": {
+        const build = await this.buildHeadroomArtifact()
+        const formula = this.renderHeadroomFormula(
+          `file:///artifacts/${build.assetName}`,
+          build.version,
+          build.sha256,
+        )
+        const smokeTap = tap.withNewFile("Formula/headroom-self-hosted.rb", formula)
+
+        return dag
+          .container()
+          .from(BREW_IMAGE)
+          .withUser("root")
+          .withEnvVariable("HOMEBREW_NO_AUTO_UPDATE", "1")
+          .withEnvVariable("HOMEBREW_NO_ENV_HINTS", "1")
+          .withEnvVariable("HOMEBREW_NO_INSTALL_FROM_API", "1")
+          .withDirectory("/tap", smokeTap)
+          .withFile(`/artifacts/${build.assetName}`, build.container.file(build.artifactPath))
+          .withExec([
+            "bash",
+            "-lc",
+            [
+              "set -euo pipefail",
+              "repo=$(brew --repository)",
+              "tap_dir=\"$repo/Library/Taps/test/homebrew-tap\"",
+              ...tapStagingCommands("headroom-self-hosted"),
+              "brew install test/tap/headroom-self-hosted",
+              "brew test test/tap/headroom-self-hosted",
+              "test -x \"$(brew --prefix)/bin/headroom\"",
+              "headroom --help",
+              "headroom proxy --help",
+            ].join("\n"),
+          ])
+          .stdout()
+      }
       case "codex-desktop-linux": {
         const build = await this.buildCodexDesktopFixtureArtifact(tap)
         const sha256 = (
@@ -3655,6 +3835,10 @@ end
         const build = await this.buildT3CodeArtifact(tap, "main")
         return json(this.t3CodeReleaseMetadata(build))
       }
+      case "headroom-self-hosted": {
+        const build = await this.buildHeadroomArtifact()
+        return json(this.headroomReleaseMetadata(build))
+      }
       case "codex-desktop-linux": {
         void codexDesktopConversionCommit
         throw new Error(
@@ -3927,6 +4111,22 @@ end
           .withFile("homebrew/t3-code-linux.rb", dag.file("t3-code-linux.rb", updatedCask))
           .withFile("release.json", dag.file("release.json", json(release)))
           .withFile("ci.log", dag.file("ci.log", ciLog))
+      }
+      case "headroom-self-hosted": {
+        const build = await this.buildHeadroomArtifact()
+        const release = this.headroomReleaseMetadata(build)
+        const formula = this.renderHeadroomFormula(
+          String(release.download_url),
+          build.version,
+          build.sha256,
+        )
+
+        return dag.directory()
+          .withFile(`artifacts/${build.assetName}`, build.container.file(build.artifactPath))
+          .withNewFile("homebrew/headroom-self-hosted.rb", formula)
+          .withNewFile("release.json", json(release))
+          .withNewFile("provenance.json", json(this.headroomProvenance(build)))
+          .withNewFile("ci.log", ciLog)
       }
       case "codex-desktop-linux": {
         throw new Error(

--- a/dagger/tap-pipeline/src/library.ts
+++ b/dagger/tap-pipeline/src/library.ts
@@ -100,6 +100,24 @@ export const PACKAGE_REGISTRY: PackageRegistryEntry[] = [
     },
   },
   {
+    id: "headroom-self-hosted",
+    kind: "headroom_self_hosted_formula",
+    homebrewPath: "Formula/headroom-self-hosted.rb",
+    supportsPrCi: true,
+    supportsReleaseBundle: true,
+    autoUpdate: {
+      kind: "git_head_sha",
+      ref: "self-hosted",
+      prefix: "selfhosted.",
+      shaLength: 12,
+    },
+    upstream: {
+      kind: "git",
+      repo: "https://github.com/joshyorko/headroom",
+      ref: "ad7eea0d310c13278965a54488dbb6a9e3162d33",
+    },
+  },
+  {
     id: "devsy",
     kind: "http_binary_formula",
     homebrewPath: "Formula/devsy.rb",
@@ -378,6 +396,7 @@ const CHANGED_PATHS: Array<[string, string[]]> = [
   ],
   ["antigravity-cli", ["Formula/antigravity-cli.rb"]],
   ["chatgpt", ["Casks/chatgpt.rb"]],
+  ["headroom-self-hosted", ["Formula/headroom-self-hosted.rb"]],
   ["devsy", ["Formula/devsy.rb"]],
   ["devsy-desktop", ["Casks/devsy-desktop.rb"]],
   [

--- a/dagger/tap-pipeline/src/types.ts
+++ b/dagger/tap-pipeline/src/types.ts
@@ -10,6 +10,7 @@ export type PackageKind =
   | "github_release_binary_cask"
   | "github_release_deb_cask"
   | "github_release_appimage_cask"
+  | "headroom_self_hosted_formula"
   | "codex_desktop_linux_cask"
 
 export type AutoUpdateSlotId =
@@ -24,6 +25,7 @@ export type AutoUpdateSlotId =
   | "fizzy-daily"
   | "buzz-daily"
   | "chatgpt-daily"
+  | "headroom-daily"
 
 export type UpstreamSource =
   | {

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -254,7 +254,7 @@ test("t3-code-linux builds the desktop AppImage from upstream main", () => {
   assert.match(source, /grep -Fq .*squashfs-root\/AppRun/)
   assert.match(source, /! grep -Eq .*AppImage/)
 
-  assert.match(cask, /^\s*version "main\.20260805114256\.2a04db134c2d,1"$/m)
+  assert.match(cask, /^\s*version "main\.20260812125613\.e321667b100a"$/m)
   assert.match(cask, /T3-Code-#\{version\.csv\.first\}-#\{arch\}\.AppImage/)
   assert.match(cask, /app_run = "#\{staged_path\}\/squashfs-root\/AppRun"/)
   assert.match(cask, /raise "T3 Code AppRun is not executable" unless File\.executable\?\(app_run\)/)
@@ -356,7 +356,7 @@ test("Devsy packages pin stable release assets and keep CLI and Desktop identiti
   const renderer = readFileSync(new URL("../src/devsy-render.ts", import.meta.url), "utf8")
   const readme = readFileSync(new URL("../../../README.md", import.meta.url), "utf8")
   const formulaVersion = formula.match(/^\s*version "(\d+\.\d+\.\d+)"$/m)?.[1]
-  const caskVersionMatch = cask.match(/^\s*version "(\d+\.\d+\.\d+),(\d+)"$/m)
+  const caskVersionMatch = cask.match(/^\s*version "(\d+\.\d+\.\d+)(?:,(\d+))?"$/m)
   const caskVersion = caskVersionMatch?.[1]
   const caskRevision = caskVersionMatch?.[2]
   const formulaUrls = [...formula.matchAll(/^\s*url "([^"]+)"$/gm)].map((match) => match[1])
@@ -383,7 +383,7 @@ test("Devsy packages pin stable release assets and keep CLI and Desktop identiti
   assert.match(cask, /depends_on arch: :x86_64/)
   assert.doesNotMatch(cask, /arch arm/)
   assert.equal(caskVersion, formulaVersion)
-  assert.equal(caskRevision, "1")
+  assert.equal(caskRevision, undefined)
   assert.match(caskUrl ?? "", new RegExp(`/(?:v|devsy-desktop-)${caskVersion}/Devsy_linux_x86_64\\.AppImage$`))
   assert.match(caskDigest ?? "", /^[a-f0-9]{64}$/)
   assert.match(cask, /target: "devsy-desktop"/)

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -28,6 +28,7 @@ test("package registry covers every planned adapter kind", () => {
       "github_release_appimage_cask",
       "github_release_binary_cask",
       "github_release_deb_cask",
+      "headroom_self_hosted_formula",
       "http_binary_formula",
     "rpm_repack_cask",
       "source_build_go_formula",
@@ -101,6 +102,7 @@ test("auto-update slots cover the expected package set", () => {
       "fizzy-cli-master",
       "fizzy-popper-self-hosted",
       "fizzy-symphony",
+      "headroom-self-hosted",
       "rcc",
       "t3-code-linux",
       "t3code-cli-main",
@@ -416,6 +418,44 @@ test("codex desktop is not registered for tap auto-update or release publishing"
   const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "codex-desktop-linux")
 
   assert.equal(entry, undefined)
+})
+
+test("Headroom self-hosted retains an offline proxy wheelhouse with complete provenance", () => {
+  const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "headroom-self-hosted")
+  const pipeline = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8")
+
+  assert.ok(entry)
+  assert.equal(entry.kind, "headroom_self_hosted_formula")
+  assert.equal(entry.homebrewPath, "Formula/headroom-self-hosted.rb")
+  assert.equal(entry.supportsPrCi, true)
+  assert.equal(entry.supportsReleaseBundle, true)
+  assert.equal(entry.autoUpdate.kind, "git_head_sha")
+  assert.equal(entry.autoUpdate.ref, "self-hosted")
+  assert.equal(entry.upstream.kind, "git")
+  assert.equal(entry.upstream.repo, "https://github.com/joshyorko/headroom")
+  assert.equal(entry.upstream.ref, "ad7eea0d310c13278965a54488dbb6a9e3162d33")
+  assert.match(pipeline, /python:3\.13-bookworm/)
+  assert.match(pipeline, /python -m pip wheel[^\n]+\.\[proxy\]/)
+  assert.match(pipeline, /source_tree: treeHash/)
+  assert.match(pipeline, /artifact_sha256: build\.sha256/)
+  assert.match(pipeline, /withNewFile\("provenance\.json"/)
+  assert.match(pipeline, /brew test test\/tap\/headroom-self-hosted/)
+  assert.match(pipeline, /headroom --help/)
+  assert.match(pipeline, /headroom proxy --help/)
+  assert.match(pipeline, /--no-index/)
+  assert.match(pipeline, /--find-links=#\{libexec\}\/wheelhouse/)
+  assert.doesNotMatch(pipeline, /rm_rf libexec\/"wheelhouse"/)
+})
+
+test("Headroom self-hosted has a daily and explicitly dispatchable update slot", () => {
+  const workflow = readFileSync(new URL("../../../.github/workflows/tap-auto-update.yml", import.meta.url), "utf8")
+  const slot = AUTO_UPDATE_SLOTS.find((candidate) => candidate.id === "headroom-daily")
+
+  assert.ok(slot)
+  assert.deepEqual(slot.packageIds, ["headroom-self-hosted"])
+  assert.match(workflow, /- cron: "31 10 \* \* \*"/)
+  assert.match(workflow, /- headroom-daily/)
+  assert.match(workflow, /"31 10 \* \* \*"\) slot_id="headroom-daily"/)
 })
 
 test("t3code CLI builders do not rewrite the upstream runtime package version", () => {

--- a/dagger/tap-pipeline/tests/contract.test.ts
+++ b/dagger/tap-pipeline/tests/contract.test.ts
@@ -423,6 +423,10 @@ test("codex desktop is not registered for tap auto-update or release publishing"
 test("Headroom self-hosted retains an offline proxy wheelhouse with complete provenance", () => {
   const entry = PACKAGE_REGISTRY.find((candidate) => candidate.id === "headroom-self-hosted")
   const pipeline = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8")
+  const headroomCi = pipeline.slice(
+    pipeline.indexOf('case "headroom-self-hosted": {', pipeline.indexOf("async ciCheck")),
+    pipeline.indexOf('case "codex-desktop-linux": {', pipeline.indexOf("async ciCheck")),
+  )
 
   assert.ok(entry)
   assert.equal(entry.kind, "headroom_self_hosted_formula")
@@ -445,6 +449,7 @@ test("Headroom self-hosted retains an offline proxy wheelhouse with complete pro
   assert.match(pipeline, /--no-index/)
   assert.match(pipeline, /--find-links=#\{libexec\}\/wheelhouse/)
   assert.doesNotMatch(pipeline, /rm_rf libexec\/"wheelhouse"/)
+  assert.match(headroomCi, /\.from\(BREW_IMAGE\)\s*\.withUser\("linuxbrew"\)/)
 })
 
 test("Headroom self-hosted has a daily and explicitly dispatchable update slot", () => {

--- a/dagger/tap-pipeline/tests/planner.test.ts
+++ b/dagger/tap-pipeline/tests/planner.test.ts
@@ -121,6 +121,7 @@ test("every PR-enabled package has a changed-path trigger", () => {
     "action-server": "Casks/action-server.rb",
     "devpod-linux": "Casks/devpod-linux.rb",
     "t3-code-linux": "Casks/t3-code-linux.rb",
+    "headroom-self-hosted": "Formula/headroom-self-hosted.rb",
   }
 
   for (const entry of PACKAGE_REGISTRY.filter((candidate) => candidate.supportsPrCi)) {

--- a/docs/superpowers/plans/2026-08-13-headroom-self-hosted-homebrew.md
+++ b/docs/superpowers/plans/2026-08-13-headroom-self-hosted-homebrew.md
@@ -1,0 +1,63 @@
+# Headroom Self-Hosted Homebrew Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and validate an offline-installable Headroom self-hosted Homebrew release bundle from an exact source commit.
+
+**Architecture:** Extend the existing tap package registry and Dagger adapter switch with one Headroom source builder, formula renderer, CI path, metadata path, and bundle path. Retain the complete wheelhouse in the artifact and emit final provenance beside it in the release bundle.
+
+**Tech Stack:** Dagger TypeScript, Python 3.13, pip wheel, Homebrew formula Ruby, GitHub Actions.
+
+## Global Constraints
+
+- Work only on `patchraptor/headroom-homebrew-release` in the supplied persistent worktree.
+- Pin commit `ad7eea0d310c13278965a54488dbb6a9e3162d33` and tree `5ff8a07cfb70e8912dfcbd04d60282472e931199`.
+- Use Python 3.13 and `headroom-ai[proxy]`.
+- Install through Homebrew with `--no-index` and `--find-links`.
+- Do not publish a GitHub Release, deploy Headroom, or mutate `main`.
+
+---
+
+### Task 1: Registry and automation contract
+
+**Files:**
+- Modify: `dagger/tap-pipeline/src/types.ts`
+- Modify: `dagger/tap-pipeline/src/library.ts`
+- Modify: `dagger/tap-pipeline/auto-update-slots.json`
+- Modify: `.github/workflows/tap-auto-update.yml`
+- Modify: `dagger/tap-pipeline/tests/contract.test.ts`
+- Modify: `dagger/tap-pipeline/tests/planner.test.ts`
+
+- [ ] Add failing contract tests for the package identity, exact source pin, changed path, release capability, and daily/dispatch slot.
+- [ ] Run focused Node tests and confirm they fail for missing Headroom registration.
+- [ ] Add the minimal registry, type, changed-path, and workflow entries.
+- [ ] Rerun focused Node tests and confirm they pass.
+
+### Task 2: Source build, formula, and provenance
+
+**Files:**
+- Create: `Formula/headroom-self-hosted.rb`
+- Modify: `dagger/tap-pipeline/src/index.ts`
+- Modify: `dagger/tap-pipeline/tests/contract.test.ts`
+
+- [ ] Add failing contract assertions for Python 3.13, proxy wheel build, complete wheelhouse retention, offline pip flags, source tree hash, artifact checksum provenance, and CLI checks.
+- [ ] Run the focused contract test and confirm it fails.
+- [ ] Implement the Headroom builder, formula renderer, CI check, release metadata, and release bundle with final provenance.
+- [ ] Rerun focused tests and TypeScript checks.
+
+### Task 3: Checkpoint publication
+
+**Files:** all Headroom-scoped paths from Tasks 1-2 and these design/plan documents.
+
+- [ ] Verify diff scope, static tests, formatting, and source pin.
+- [ ] Commit the coherent implementation checkpoint.
+- [ ] Push the specified branch and open a draft PR against `main` with `gh`.
+
+### Task 4: End-to-end acceptance
+
+**Files:** no source changes unless evidence exposes a Headroom packaging defect.
+
+- [ ] Run one Dagger `release-bundle` lane for `headroom-self-hosted` and retain output under `/tmp`.
+- [ ] Verify artifact checksum, complete wheelhouse, internal provenance, and bundle provenance.
+- [ ] Run Dagger `ci-check` for the isolated offline Homebrew install and CLI tests.
+- [ ] Update the draft PR with exact checks and any remaining risk; push a follow-up fix only if required.

--- a/docs/superpowers/specs/2026-08-13-headroom-self-hosted-homebrew-design.md
+++ b/docs/superpowers/specs/2026-08-13-headroom-self-hosted-homebrew-design.md
@@ -1,0 +1,24 @@
+# Headroom Self-Hosted Homebrew Design
+
+## Goal
+
+Package the exact current `joshyorko/headroom:self-hosted` source as the `headroom-self-hosted` Homebrew formula and integrate it with the tap's standard CI, release-bundle, and auto-update workflows.
+
+## Source and artifact contract
+
+- Source repository: `https://github.com/joshyorko/headroom`
+- Source ref: `self-hosted`
+- Pinned commit: `ad7eea0d310c13278965a54488dbb6a9e3162d33`
+- Source tree: `5ff8a07cfb70e8912dfcbd04d60282472e931199`
+- Build image: Python 3.13 Bookworm
+- Build profile: `headroom-ai[proxy]`
+
+The Dagger builder creates the project wheel and every resolved dependency wheel in one retained wheelhouse. The release artifact contains that complete wheelhouse and internal build provenance. The release bundle adds final provenance containing the source repository, ref, exact commit, tree hash, artifact SHA256, build profile, and Python version.
+
+## Homebrew and validation contract
+
+The generated formula creates a Python 3.13 virtual environment and installs only from the retained wheelhouse with `--no-index` and `--find-links`. CI installs from a local artifact in an isolated Homebrew container, runs `brew test`, and directly checks `headroom --help` plus `headroom proxy --help`.
+
+## Automation contract
+
+`PACKAGE_REGISTRY`, changed-path detection, release metadata, and standard release-bundle generation own the package. A `headroom-daily` slot tracks the `self-hosted` branch head and is both scheduled daily and explicitly dispatchable. Publication remains a separate workflow action; this change does not publish a release.

--- a/recovery/Brewfile
+++ b/recovery/Brewfile
@@ -1,5 +1,7 @@
 # Generated from dagger/tap-pipeline/src/library.ts package registry.
 brew "joshyorko/tools/t3code-cli-main"
+cask "joshyorko/tools/chatgpt"
+brew "joshyorko/tools/headroom-self-hosted"
 brew "joshyorko/tools/devsy"
 cask "joshyorko/tools/devsy-desktop"
 cask "joshyorko/tools/buzz-linux"


### PR DESCRIPTION
## What changed

- add `headroom-self-hosted` to the tap registry, changed-path routing, release metadata, and release-bundle adapter
- build the current `joshyorko/headroom:self-hosted` source with Python 3.13 and the proxy extras
- retain the complete offline wheelhouse and emit source/build/artifact provenance
- install through Homebrew with `--no-index` and `--find-links`
- add daily and manual-dispatch automation plus isolated Homebrew CLI acceptance
- include release-capable ChatGPT and Headroom packages in the recovery inventory, and refresh stale T3/Devsy test fixtures to current package truth

## Source pin

- repository/ref: `https://github.com/joshyorko/headroom`, `self-hosted`
- commit: `ad7eea0d310c13278965a54488dbb6a9e3162d33`
- tree: `5ff8a07cfb70e8912dfcbd04d60282472e931199`
- build profile: `headroom-ai[proxy]`
- Python: `3.13`

## Acceptance

- full tap-pipeline npm suite: 61 passed, 0 failed
- full Dagger tap-pipeline suite: 61 passed, 0 failed
- real release bundle export completed from the pinned source
- artifact: `headroom-self-hosted-selfhosted.ad7eea0d310c.tar.gz`
- artifact SHA256: `5adb3bc82de6da46fe4e1572ead51ff887ec2b6b6a7d37dc8b0feab2e43bc299`
- retained wheelhouse: 86 wheels, including `headroom_ai-0.34.0-cp310-abi3-linux_x86_64.whl`
- bundle and internal provenance include source repository/ref/commit/tree, build profile, Python version, and artifact checksum where applicable
- isolated Linuxbrew install used `pip install --no-index --find-links=.../wheelhouse headroom-ai[proxy]==0.34.0`
- isolated `brew test`, `headroom --help`, and `headroom proxy --help` passed
- final-SHA CI run `31701686548`: tap tests, changed-package resolution, and `Package CI (headroom-self-hosted)` passed

This PR remains draft. It does not publish a GitHub Release or deploy Headroom.
