### PR TITLE
Pin corrected Headroom artifact checksum

### DIFF
--- a/Formula/headroom-self-hosted.rb
+++ b/Formula/headroom-self-hosted.rb
@@ -3,7 +3,7 @@ class HeadroomSelfHosted < Formula
   homepage "https://github.com/joshyorko/headroom"
   url "https://github.com/joshyorko/homebrew-tools/releases/download/headroom-self-hosted-selfhosted.ad7eea0d310c/headroom-self-hosted-selfhosted.ad7eea0d310c.tar.gz"
   version "selfhosted.ad7eea0d310c"
-  sha256 "43bcad1d613c56de9ac14e6b3801ac22bb152bee20c716a046c0571ad7117388"
+  sha256 "716ced286c7c655f6690f375528a2315e91e619a08e7747913de2279da8c8fb2"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/headroom-self-hosted.rb
+++ b/Formula/headroom-self-hosted.rb
@@ -3,7 +3,7 @@ class HeadroomSelfHosted < Formula
   homepage "https://github.com/joshyorko/headroom"
   url "https://github.com/joshyorko/homebrew-tools/releases/download/headroom-self-hosted-selfhosted.ad7eea0d310c/headroom-self-hosted-selfhosted.ad7eea0d310c.tar.gz"
   version "selfhosted.ad7eea0d310c"
-  sha256 "5adb3bc82de6da46fe4e1572ead51ff887ec2b6b6a7d37dc8b0feab2e43bc299"
+  sha256 "43bcad1d613c56de9ac14e6b3801ac22bb152bee20c716a046c0571ad7117388"
   license "Apache-2.0"
 
   livecheck do


### PR DESCRIPTION
## What changed

- update `Formula/headroom-self-hosted.rb` to the checksum of the corrected artifact published after #86

## Evidence

- published artifact SHA256/GitHub digest: `716ced286c7c655f6690f375528a2315e91e619a08e7747913de2279da8c8fb2`
- downloaded release asset matches GitHub's reported digest
- internal artifact provenance parses as JSON and matches source commit `ad7eea0d310c13278965a54488dbb6a9e3162d33`, tree `5ff8a07cfb70e8912dfcbd04d60282472e931199`, profile `headroom-ai[proxy]`, and Python `3.13`
- complete wheelhouse: 86 wheels
- isolated offline Linuxbrew install/test and both Headroom help commands passed
- full tap-pipeline npm suite: 61 passed, 0 failed

This PR remains draft. It does not publish a GitHub Release or deploy Headroom.
