### PR TITLE
Fix Codex Desktop Homebrew launcher

### DIFF
--- a/Casks/codex-desktop.rb
+++ b/Casks/codex-desktop.rb
@@ -47,6 +47,17 @@ cask "codex-desktop" do
       "Icon=#{Dir.home}/.local/share/icons/hicolor/256x256/apps/codex-desktop.png"
     )
     File.write(desktop_file, desktop_contents)
+
+    launcher_path = "#{staged_path}/usr/bin/codex-desktop"
+    launcher_contents = <<~SH
+      #!/usr/bin/env bash
+      set -euo pipefail
+      launcher="$(readlink -f "${BASH_SOURCE[0]}")"
+      app_root="$(cd "$(dirname "$launcher")/../../opt/codex-desktop" && pwd)"
+      exec "$app_root/start.sh" "$@"
+    SH
+    File.write(launcher_path, launcher_contents)
+    FileUtils.chmod(0755, launcher_path)
   end
 
   zap trash: [

--- a/dagger/tap-pipeline/src/index.ts
+++ b/dagger/tap-pipeline/src/index.ts
@@ -1531,6 +1531,17 @@ end
       "Icon=#{Dir.home}/.local/share/icons/hicolor/256x256/apps/codex-desktop.png"
     )
     File.write(desktop_file, desktop_contents)
+
+    launcher_path = "#{staged_path}/usr/bin/codex-desktop"
+    launcher_contents = <<~SH
+      #!/usr/bin/env bash
+      set -euo pipefail
+      launcher="$(readlink -f "\${BASH_SOURCE[0]}")"
+      app_root="$(cd "$(dirname "$launcher")/../../opt/codex-desktop" && pwd)"
+      exec "$app_root/start.sh" "$@"
+    SH
+    File.write(launcher_path, launcher_contents)
+    FileUtils.chmod(0755, launcher_path)
   end
 
   zap trash: [
@@ -3729,6 +3740,9 @@ end
               "installed_dir=$(find \"$(brew --caskroom)/codex-desktop\" -mindepth 1 -maxdepth 1 -type d -print -quit)",
               "test -x \"$installed_dir/opt/codex-desktop/ChatGPT\"",
               "test -x \"$installed_dir/opt/codex-desktop/start.sh\"",
+              "! grep -Fq 'exec /opt/codex-desktop/start.sh' \"$(brew --prefix)/bin/codex-desktop\"",
+              "codex-desktop --help >/tmp/codex-desktop-help.txt",
+              "grep -q 'Codex Desktop' /tmp/codex-desktop-help.txt",
               "test ! -e \"$installed_dir/usr/bin/codex-update-manager\"",
               "test -f \"$HOME/.local/share/applications/codex-desktop.desktop\"",
               "grep -Fq \"Exec=$(brew --prefix)/bin/codex-desktop %u\" \"$HOME/.local/share/applications/codex-desktop.desktop\"",
@@ -4660,6 +4674,7 @@ end
           "installed_dir=$(find \"$(brew --caskroom)/codex-desktop\" -mindepth 1 -maxdepth 1 -type d -print -quit)",
           "test -x \"$installed_dir/opt/codex-desktop/ChatGPT\"",
           "test -x \"$installed_dir/opt/codex-desktop/start.sh\"",
+          "! grep -Fq 'exec /opt/codex-desktop/start.sh' \"$(brew --prefix)/bin/codex-desktop\"",
           "test ! -e \"$installed_dir/usr/bin/codex-update-manager\"",
           "build_info=$(find \"$installed_dir\" -path '*/.codex-linux/build-info.json' -print -quit)",
           "test -n \"$build_info\"",

--- a/dagger/tap-pipeline/tests/codex-desktop.test.ts
+++ b/dagger/tap-pipeline/tests/codex-desktop.test.ts
@@ -617,7 +617,12 @@ test("codex desktop official flow is normal and legacy DMG conversion stays expl
   ]
 
   const officialSetup = readFileSync(new URL("../../../scripts/setup-codex-desktop-official.sh", import.meta.url), "utf8")
+  const officialInstall = readFileSync(new URL("../../../scripts/install-codex-desktop-official.sh", import.meta.url), "utf8")
   const releaseFeatures = readFileSync(new URL("../../../config/codex-desktop-linux-features.json", import.meta.url), "utf8")
+  const officialCaskRenderer = pipeline.slice(
+    pipeline.indexOf("private renderCodexDesktopOfficialCask"),
+    pipeline.indexOf("private renderCodexDesktopOfficialCask") + 12_000,
+  )
   assert.deepEqual(JSON.parse(releaseFeatures), { enabled: [] })
   assert.match(officialSetup, /release-bundle/)
   assert.match(officialSetup, /codex-desktop-offline-smoke/)
@@ -625,6 +630,10 @@ test("codex desktop official flow is normal and legacy DMG conversion stays expl
   assert.match(officialSetup, /codex-desktop-feature-wizard\.py/)
   assert.match(officialSetup, /config\/codex-desktop-linux-features\.json/)
   assert.doesNotMatch(officialSetup, /DMG|dmg/)
+  assert.match(officialInstall, /release_json="\$bundle_dir\/release\.json"/)
+  assert.match(officialInstall, /source_cask="\$bundle_dir\/homebrew\/codex-desktop\.rb"/)
+  assert.doesNotMatch(officialInstall, /\$bundle_dir\/\s+release\.json/)
+  assert.doesNotMatch(officialInstall, /homebrew\/\s+codex-desktop\.rb/)
   assert.match(makefile, /codex-desktop-setup:/)
   assert.match(makefile, /codex-desktop-install:/)
   assert.match(makefile, /setup-codex-desktop-official\.sh/)
@@ -645,6 +654,12 @@ test("codex desktop official flow is normal and legacy DMG conversion stays expl
   assert.match(pipeline, /linux_features_enabled: build\.linuxFeaturesEnabled/)
   assert.match(pipeline, /CODEX_LINUX_FEATURES_CONFIG=linux-features\/features\.homebrew\.json make build-native-feature-helpers/)
   assert.match(pipeline, /CODEX_LINUX_FEATURES_CONFIG=linux-features\/features\.homebrew\.json[^\n]+\.\/install\.sh \/work\/chatgpt\.deb/)
+  assert.match(pipeline, /launcher_path = "#\{staged_path\}\/usr\/bin\/codex-desktop"/)
+  assert.match(pipeline, /readlink -f/)
+  assert.match(pipeline, /BASH_SOURCE\[0\]/)
+  assert.match(pipeline, /\.\.\/\.\.\/opt\/codex-desktop/)
+  assert.doesNotMatch(officialCaskRenderer, /exec \/opt\/codex-desktop\/start\.sh/)
+  assert.match(pipeline, /! grep -Fq 'exec \/opt\/codex-desktop\/start\.sh'/)
   assert.match(pipeline, /codexDesktopLocalBundle/)
   assert.match(pipeline, /CODEX_DESKTOP_LOCAL_ARTIFACT/)
   assert.match(pipeline, /No converted Codex Desktop app payload is distributed by the tap/)


### PR DESCRIPTION
## What changed

- Rewrite the packaged Codex Desktop launcher after Homebrew staging so it resolves the application relative to its installed Caskroom path.
- Apply the same launcher behavior to generated release casks.
- Execute the installed launcher in the isolated package smoke test and reject the broken host-absolute path.
- Add regression coverage for the normal official setup/install routing and retained bundle paths.

## Root cause

The packaged launcher executed `/opt/codex-desktop/start.sh`, but Homebrew installs the payload under its versioned Caskroom. The app payload was valid; the launcher escaped the package root and exited 127.

## Validation

- `npm test --prefix dagger/tap-pipeline` (62 passing)
- shell syntax checks for official setup/install and local uninstall scripts
- `git diff --check`
- dry-run audit of all normal and legacy Codex Desktop Make targets
- Dagger tap-pipeline module function loading
