### PR TITLE
Restore Codex Desktop setup install flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ crabbox-pull-codex-desktop-legacy-archive:
 
 codex-desktop-setup:
 	CODEX_DESKTOP_LINUX_FEATURES_FULL="$(CODEX_DESKTOP_LINUX_FEATURES_FULL)" CODEX_DESKTOP_LINUX_FEATURES_LEAN="$(CODEX_DESKTOP_LINUX_FEATURES_LEAN)" CODEX_DESKTOP_BUNDLE_DIR="$(CODEX_DESKTOP_OFFICIAL_BUNDLE_DIR)" scripts/setup-codex-desktop-official.sh
+	CODEX_DESKTOP_SKIP_SETUP=1 CODEX_DESKTOP_BUNDLE_DIR="$(CODEX_DESKTOP_OFFICIAL_BUNDLE_DIR)" scripts/install-codex-desktop-official.sh
 
 codex-desktop-install:
 	CODEX_DESKTOP_BUNDLE_DIR="$(CODEX_DESKTOP_OFFICIAL_BUNDLE_DIR)" scripts/install-codex-desktop-official.sh

--- a/dagger/tap-pipeline/tests/codex-desktop.test.ts
+++ b/dagger/tap-pipeline/tests/codex-desktop.test.ts
@@ -635,6 +635,10 @@ test("codex desktop official flow is normal and legacy DMG conversion stays expl
   assert.doesNotMatch(officialInstall, /\$bundle_dir\/\s+release\.json/)
   assert.doesNotMatch(officialInstall, /homebrew\/\s+codex-desktop\.rb/)
   assert.match(makefile, /codex-desktop-setup:/)
+  assert.match(
+    makefile,
+    /^codex-desktop-setup:\n\t[^\n]*setup-codex-desktop-official\.sh\n\tCODEX_DESKTOP_SKIP_SETUP=1 [^\n]*install-codex-desktop-official\.sh$/m,
+  )
   assert.match(makefile, /codex-desktop-install:/)
   assert.match(makefile, /setup-codex-desktop-official\.sh/)
   assert.match(makefile, /install-codex-desktop-official\.sh/)


### PR DESCRIPTION
## What changed

- Restore `make codex-desktop-setup` as the complete local flow: configure, build, smoke-test, and install.
- Reuse the retained, verified bundle during installation instead of triggering setup a second time.
- Add a regression assertion for the one-command Make contract.

## Validation

- `npm test --prefix dagger/tap-pipeline` (62 passing)
- `make -n codex-desktop-setup`
- shell syntax checks for the official setup and install scripts
- `git diff --check`
